### PR TITLE
Fix the `make test` makefile target

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 SOURCE_FILES := $(shell find * | grep -v cloud-platform)
-DIRS_WITH_TESTS := $(shell find pkg cmd -type f -name '*_test.go' | xargs dirname | sort | uniq)
+DIRS_WITH_TESTS := $(shell find pkg cmd -type f -name '*_test.go' | xargs -n 1 dirname | sort | uniq)
 
 cloud-platform: $(SOURCE_FILES)
 	go mod download


### PR DESCRIPTION
Without this change, the `make test` command will fail if there is more
than one `**/*_test.go` file, because `dirname` takes one and only one
argument. This was not a problem in #10 because there was only one test
file.