### PR TITLE
Restructure the code to make it more testable

### DIFF
--- a/pkg/environment/common.go
+++ b/pkg/environment/common.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 )
 
+const CloudPlatformEnvRepo = "cloud-platform-environments"
 const namespaceBaseFolder = "namespaces/live-1.cloud-platform.service.justice.gov.uk"
 
 // metadataFromNamespace holds folder names (environments names) from
@@ -39,7 +40,7 @@ func (s *metadataFromNamespace) checkPath() (bool, error) {
 	s.envRepoPath = FullPath
 	repoName := filepath.Base(FullPath)
 
-	if repoName != "cloud-platform-environments" {
+	if repoName != CloudPlatformEnvRepo {
 		return false, errors.New("You are outside cloud-platform-environment repo")
 	}
 

--- a/pkg/environment/common.go
+++ b/pkg/environment/common.go
@@ -48,18 +48,6 @@ func (s *metadataFromNamespace) checkPath() (bool, error) {
 	return true, nil
 }
 
-func (s *metadataFromNamespace) getNamespaceFromPath() error {
-	path, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
-	parts := strings.Split(path, "/")
-	s.namespace = parts[len(parts)-1]
-
-	return nil
-}
-
 func outputFileWriter(fileName string) (*os.File, error) {
 	f, err := os.Create(fileName)
 	if err != nil {

--- a/pkg/environment/common.go
+++ b/pkg/environment/common.go
@@ -5,15 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
-
-	"gopkg.in/yaml.v2"
 )
 
 // all yaml and terraform templates will be pulled from URL endpoints below here
@@ -34,50 +31,6 @@ type metadataFromNamespace struct {
 	sourceCode      string
 	namespace       string
 	envRepoPath     string
-}
-
-func (s *metadataFromNamespace) getNamespaceMetadata() error {
-	type envNamespace struct {
-		APIVersion string `yaml:"apiVersion"`
-		Kind       string `yaml:"kind"`
-		Metadata   struct {
-			Name   string `yaml:"name"`
-			Labels struct {
-				CloudPlatformJusticeGovUkIsProduction    string `yaml:"cloud-platform.justice.gov.uk/is-production"`
-				CloudPlatformJusticeGovUkEnvironmentName string `yaml:"cloud-platform.justice.gov.uk/environment-name"`
-			} `yaml:"labels"`
-			Annotations struct {
-				CloudPlatformJusticeGovUkBusinessUnit string `yaml:"cloud-platform.justice.gov.uk/business-unit"`
-				CloudPlatformJusticeGovUkApplication  string `yaml:"cloud-platform.justice.gov.uk/application"`
-				CloudPlatformJusticeGovUkOwner        string `yaml:"cloud-platform.justice.gov.uk/owner"`
-				CloudPlatformJusticeGovUkSourceCode   string `yaml:"cloud-platform.justice.gov.uk/source-code"`
-			} `yaml:"annotations"`
-		} `yaml:"metadata"`
-	}
-
-	t := envNamespace{}
-
-	namespaceFile, err := ioutil.ReadFile(fmt.Sprintf("%s/%s/%s/00-namespace.yaml", s.envRepoPath, namespaceBaseFolder, s.namespace))
-	if err != nil {
-		return err
-	}
-
-	err = yaml.Unmarshal(namespaceFile, &t)
-	if err != nil {
-		log.Fatalf("Could not decode YAML (probably an error within 00-namespace.yaml file): %v", err)
-		return err
-	}
-
-	s.isProduction = t.Metadata.Labels.CloudPlatformJusticeGovUkIsProduction
-	s.businessUnit = t.Metadata.Annotations.CloudPlatformJusticeGovUkBusinessUnit
-	s.owner = t.Metadata.Annotations.CloudPlatformJusticeGovUkOwner
-	s.environmentName = t.Metadata.Labels.CloudPlatformJusticeGovUkEnvironmentName
-	s.ownerEmail = strings.Split(t.Metadata.Annotations.CloudPlatformJusticeGovUkOwner, ": ")[1]
-	s.application = t.Metadata.Annotations.CloudPlatformJusticeGovUkApplication
-	s.sourceCode = t.Metadata.Annotations.CloudPlatformJusticeGovUkSourceCode
-	s.namespace = t.Metadata.Name
-
-	return nil
 }
 
 func (s *metadataFromNamespace) checkNamespaceExist() error {

--- a/pkg/environment/common.go
+++ b/pkg/environment/common.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-const CloudPlatformEnvRepo = "cloud-platform-environments"
+const cloudPlatformEnvRepo = "cloud-platform-environments"
 const namespaceBaseFolder = "namespaces/live-1.cloud-platform.service.justice.gov.uk"
 
 func outputFileWriter(fileName string) (*os.File, error) {

--- a/pkg/environment/common.go
+++ b/pkg/environment/common.go
@@ -70,14 +70,7 @@ func (s *metadataFromNamespace) getNamespaceFromPath() error {
 }
 
 func outputFileWriter(fileName string) (*os.File, error) {
-	EnvRepoPath, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
-	if err != nil {
-		return nil, err
-	}
-
-	fullPath := fmt.Sprintf("%s/%s", strings.TrimSpace(string(EnvRepoPath)), fileName)
-
-	f, err := os.Create(fullPath)
+	f, err := os.Create(fileName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/environment/common.go
+++ b/pkg/environment/common.go
@@ -15,38 +15,6 @@ import (
 const CloudPlatformEnvRepo = "cloud-platform-environments"
 const namespaceBaseFolder = "namespaces/live-1.cloud-platform.service.justice.gov.uk"
 
-// metadataFromNamespace holds folder names (environments names) from
-// cloud-platform-environments repository
-type metadataFromNamespace struct {
-	FileName        string
-	Content         string
-	isProduction    string
-	environmentName string
-	businessUnit    string
-	application     string
-	owner           string
-	ownerEmail      string
-	sourceCode      string
-	namespace       string
-	envRepoPath     string
-}
-
-func (s *metadataFromNamespace) checkPath() (bool, error) {
-	path, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
-	if err != nil {
-		return false, errors.New("You are outside cloud-platform-environment repo")
-	}
-	FullPath := strings.TrimSpace(string(path))
-	s.envRepoPath = FullPath
-	repoName := filepath.Base(FullPath)
-
-	if repoName != CloudPlatformEnvRepo {
-		return false, errors.New("You are outside cloud-platform-environment repo")
-	}
-
-	return true, nil
-}
-
 func outputFileWriter(fileName string) (*os.File, error) {
 	f, err := os.Create(fileName)
 	if err != nil {

--- a/pkg/environment/common.go
+++ b/pkg/environment/common.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 )
 
-// all yaml and terraform templates will be pulled from URL endpoints below here
-const templatesBaseUrl = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/main/namespace-resources-cli-template"
 const namespaceBaseFolder = "namespaces/live-1.cloud-platform.service.justice.gov.uk"
 
 // metadataFromNamespace holds folder names (environments names) from

--- a/pkg/environment/common.go
+++ b/pkg/environment/common.go
@@ -3,7 +3,6 @@ package environment
 import (
 	"bufio"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -31,14 +30,6 @@ type metadataFromNamespace struct {
 	sourceCode      string
 	namespace       string
 	envRepoPath     string
-}
-
-func (s *metadataFromNamespace) checkNamespaceExist() error {
-	_, err := ioutil.ReadFile(fmt.Sprintf("%s/%s/%s/00-namespace.yaml", s.envRepoPath, namespaceBaseFolder, s.namespace))
-	if err != nil {
-		return errors.New("You are in the wrong folder, go to your namespace folder")
-	}
-	return nil
 }
 
 func (s *metadataFromNamespace) checkPath() (bool, error) {

--- a/pkg/environment/fixtures/foobar-namespace.yml
+++ b/pkg/environment/fixtures/foobar-namespace.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foobar
+  labels:
+    cloud-platform.justice.gov.uk/is-production: "false"
+    cloud-platform.justice.gov.uk/environment-name: "development"
+  annotations:
+    cloud-platform.justice.gov.uk/business-unit: "MoJ Digital"
+    cloud-platform.justice.gov.uk/application: "David Salgado test namespace"
+    cloud-platform.justice.gov.uk/owner: "Cloud Platform: david.salgado@digital.justice.gov.uk"
+    cloud-platform.justice.gov.uk/source-code: "https://github.com/ministryofjustice/cloud-platform-environments"

--- a/pkg/environment/namespace.go
+++ b/pkg/environment/namespace.go
@@ -8,6 +8,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const NamespaceYamlFile = "00-namespace.yaml"
+
 type Namespace struct {
 	name            string
 	isProduction    string
@@ -20,6 +22,11 @@ type Namespace struct {
 	namespace       string
 }
 
+func (ns *Namespace) ReadYaml() error {
+	return ns.ReadYamlFile(NamespaceYamlFile)
+}
+
+// This is a public function so that we can use it in our tests
 func (ns *Namespace) ReadYamlFile(filename string) error {
 	contents, err := ioutil.ReadFile(filename)
 	if err != nil {

--- a/pkg/environment/namespace.go
+++ b/pkg/environment/namespace.go
@@ -22,12 +22,12 @@ type Namespace struct {
 	namespace       string
 }
 
-func (ns *Namespace) ReadYaml() error {
-	return ns.ReadYamlFile(NamespaceYamlFile)
+func (ns *Namespace) readYaml() error {
+	return ns.readYamlFile(NamespaceYamlFile)
 }
 
 // This is a public function so that we can use it in our tests
-func (ns *Namespace) ReadYamlFile(filename string) error {
+func (ns *Namespace) readYamlFile(filename string) error {
 	contents, err := ioutil.ReadFile(filename)
 	if err != nil {
 		fmt.Printf("Failed to read namespace YAML file: %s", filename)

--- a/pkg/environment/namespace.go
+++ b/pkg/environment/namespace.go
@@ -1,0 +1,71 @@
+package environment
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+type Namespace struct {
+	name            string
+	isProduction    string
+	businessUnit    string
+	owner           string
+	environmentName string
+	ownerEmail      string
+	application     string
+	sourceCode      string
+	namespace       string
+}
+
+func (ns *Namespace) ReadYamlFile(filename string) error {
+	contents, err := ioutil.ReadFile(filename)
+	if err != nil {
+		fmt.Printf("Failed to read namespace YAML file: %s", filename)
+		return err
+	}
+	ns.parseYaml(contents)
+	return nil
+}
+
+func (ns *Namespace) parseYaml(yamlData []byte) error {
+	type envNamespace struct {
+		APIVersion string `yaml:"apiVersion"`
+		Kind       string `yaml:"kind"`
+		Metadata   struct {
+			Name   string `yaml:"name"`
+			Labels struct {
+				IsProduction    string `yaml:"cloud-platform.justice.gov.uk/is-production"`
+				EnvironmentName string `yaml:"cloud-platform.justice.gov.uk/environment-name"`
+			} `yaml:"labels"`
+			Annotations struct {
+				BusinessUnit string `yaml:"cloud-platform.justice.gov.uk/business-unit"`
+				Application  string `yaml:"cloud-platform.justice.gov.uk/application"`
+				Owner        string `yaml:"cloud-platform.justice.gov.uk/owner"`
+				SourceCode   string `yaml:"cloud-platform.justice.gov.uk/source-code"`
+			} `yaml:"annotations"`
+		} `yaml:"metadata"`
+	}
+
+	t := envNamespace{}
+
+	err := yaml.Unmarshal(yamlData, &t)
+	if err != nil {
+		fmt.Printf("Could not decode namespace YAML: %v", err)
+		return err
+	}
+
+	ns.name = t.Metadata.Name
+	ns.isProduction = t.Metadata.Labels.IsProduction
+	ns.businessUnit = t.Metadata.Annotations.BusinessUnit
+	ns.owner = t.Metadata.Annotations.Owner
+	ns.environmentName = t.Metadata.Labels.EnvironmentName
+	ns.ownerEmail = strings.Split(t.Metadata.Annotations.Owner, ": ")[1]
+	ns.application = t.Metadata.Annotations.Application
+	ns.sourceCode = t.Metadata.Annotations.SourceCode
+	ns.namespace = t.Metadata.Name
+
+	return nil
+}

--- a/pkg/environment/namespace_test.go
+++ b/pkg/environment/namespace_test.go
@@ -15,7 +15,7 @@ func TestNamespaceName(t *testing.T) {
 // Test getting namespace information from a file
 func TestNamespaceFromYamlFile(t *testing.T) {
 	ns := Namespace{}
-	ns.ReadYamlFile("fixtures/foobar-namespace.yml")
+	ns.readYamlFile("fixtures/foobar-namespace.yml")
 	if ns.name != "foobar" {
 		t.Errorf("Expect foobar, got: %s", ns.name)
 	}

--- a/pkg/environment/namespace_test.go
+++ b/pkg/environment/namespace_test.go
@@ -1,0 +1,50 @@
+package environment
+
+import (
+	"testing"
+)
+
+// If we assign a string value to 'name', we get it back
+func TestNamespaceName(t *testing.T) {
+	ns := Namespace{name: "foobar"}
+	if ns.name != "foobar" {
+		t.Errorf("Something went wrong: %s", ns.name)
+	}
+}
+
+// Test getting namespace information from a file
+func TestNamespaceFromYamlFile(t *testing.T) {
+	ns := Namespace{}
+	ns.ReadYamlFile("fixtures/foobar-namespace.yml")
+	if ns.name != "foobar" {
+		t.Errorf("Expect foobar, got: %s", ns.name)
+	}
+
+	if ns.isProduction != "false" {
+		t.Errorf("Expect foobar, got: %s", ns.isProduction)
+	}
+
+	if ns.businessUnit != "MoJ Digital" {
+		t.Errorf("Expect foobar, got: %s", ns.businessUnit)
+	}
+
+	if ns.owner != "Cloud Platform: david.salgado@digital.justice.gov.uk" {
+		t.Errorf("Expect foobar, got: %s", ns.owner)
+	}
+
+	if ns.ownerEmail != "david.salgado@digital.justice.gov.uk" {
+		t.Errorf("Expect foobar, got: %s", ns.ownerEmail)
+	}
+
+	if ns.environmentName != "development" {
+		t.Errorf("Expect foobar, got: %s", ns.environmentName)
+	}
+
+	if ns.application != "David Salgado test namespace" {
+		t.Errorf("Expect foobar, got: %s", ns.application)
+	}
+
+	if ns.sourceCode != "https://github.com/ministryofjustice/cloud-platform-environments" {
+		t.Errorf("Expect foobar, got: %s", ns.sourceCode)
+	}
+}

--- a/pkg/environment/repoEnvironment.go
+++ b/pkg/environment/repoEnvironment.go
@@ -1,0 +1,34 @@
+package environment
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+)
+
+// Get information about the current execution context, wrt. the environments
+// repo.  Answer questions like:
+//   * Is the current directory inside a working copy of the right repository?
+//   * Does this folder contain a file with a specific name (e.g. 00-namespace.yml)?
+//   * What is the name of the namespace whose definition folder I am in?
+
+type RepoEnvironment struct {
+	repository string
+}
+
+// set and return the name of the git repository which the current working
+// directory is located within
+func (re *RepoEnvironment) Repository() (error, string) {
+	// using re.repository here allows us to override this method in tests, so
+	// that we can run tests regardless of the current working directory
+	if re.repository == "" {
+		path, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+		if err != nil {
+			return errors.New("current directory is not in a git repo working copy"), ""
+		}
+		arr := strings.Split(string(path), "/")
+		str := arr[len(arr)-1]
+		re.repository = strings.Trim(str, "\n")
+	}
+	return nil, re.repository
+}

--- a/pkg/environment/repoEnvironment.go
+++ b/pkg/environment/repoEnvironment.go
@@ -7,12 +7,6 @@ import (
 	"strings"
 )
 
-// Get information about the current execution context, wrt. the environments
-// repo.  Answer questions like:
-//   * Is the current directory inside a working copy of the right repository?
-//   * Does this folder contain a file with a specific name (e.g. 00-namespace.yml)?
-//   * What is the name of the namespace whose definition folder I am in?
-
 type RepoEnvironment struct {
 	repository string
 }

--- a/pkg/environment/repoEnvironment.go
+++ b/pkg/environment/repoEnvironment.go
@@ -2,6 +2,7 @@ package environment
 
 import (
 	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 )
@@ -14,6 +15,17 @@ import (
 
 type RepoEnvironment struct {
 	repository string
+}
+
+func (re *RepoEnvironment) MustBeInCloudPlatformEnvironments() error {
+	err, repo := re.Repository()
+	if err != nil {
+		return err
+	}
+	if repo != CloudPlatformEnvRepo {
+		return errors.New(fmt.Sprintf("This command may only be run from within a working copy of the %s repository\n", CloudPlatformEnvRepo))
+	}
+	return nil
 }
 
 // set and return the name of the git repository which the current working

--- a/pkg/environment/repoEnvironment.go
+++ b/pkg/environment/repoEnvironment.go
@@ -11,13 +11,13 @@ type RepoEnvironment struct {
 	repository string
 }
 
-func (re *RepoEnvironment) MustBeInCloudPlatformEnvironments() error {
+func (re *RepoEnvironment) mustBeInCloudPlatformEnvironments() error {
 	err, repo := re.Repository()
 	if err != nil {
 		return err
 	}
-	if repo != CloudPlatformEnvRepo {
-		return errors.New(fmt.Sprintf("This command may only be run from within a working copy of the %s repository\n", CloudPlatformEnvRepo))
+	if repo != cloudPlatformEnvRepo {
+		return errors.New(fmt.Sprintf("This command may only be run from within a working copy of the %s repository\n", cloudPlatformEnvRepo))
 	}
 	return nil
 }

--- a/pkg/environment/repoEnvironment_test.go
+++ b/pkg/environment/repoEnvironment_test.go
@@ -4,6 +4,20 @@ import (
 	"testing"
 )
 
+func TestRequireCpEnvRepo(t *testing.T) {
+	// Pass if we're in the right repository
+	re := RepoEnvironment{repository: CloudPlatformEnvRepo}
+	if re.MustBeInCloudPlatformEnvironments() != nil {
+		t.Errorf("This should have passed")
+	}
+
+	re = RepoEnvironment{}
+	err := re.MustBeInCloudPlatformEnvironments()
+	if err == nil {
+		t.Errorf("This should have failed")
+	}
+}
+
 // If we assign a string value to 'repository', we get it back
 func TestRepoEnvironmentRepository(t *testing.T) {
 	re := RepoEnvironment{repository: "foobar"}

--- a/pkg/environment/repoEnvironment_test.go
+++ b/pkg/environment/repoEnvironment_test.go
@@ -6,14 +6,14 @@ import (
 
 func TestRequireCpEnvRepo(t *testing.T) {
 	// Pass if we're in the right repository
-	re := RepoEnvironment{repository: CloudPlatformEnvRepo}
-	if re.MustBeInCloudPlatformEnvironments() != nil {
+	re := RepoEnvironment{repository: cloudPlatformEnvRepo}
+	if re.mustBeInCloudPlatformEnvironments() != nil {
 		t.Errorf("This should have passed")
 	}
 
 	// Fail if we're not in the CP-env repo (which we're not)
 	re = RepoEnvironment{}
-	err := re.MustBeInCloudPlatformEnvironments()
+	err := re.mustBeInCloudPlatformEnvironments()
 	if err == nil {
 		t.Errorf("This should have failed")
 	}

--- a/pkg/environment/repoEnvironment_test.go
+++ b/pkg/environment/repoEnvironment_test.go
@@ -1,0 +1,24 @@
+package environment
+
+import (
+	"testing"
+)
+
+// If we assign a string value to 'repository', we get it back
+func TestRepoEnvironmentRepository(t *testing.T) {
+	re := RepoEnvironment{repository: "foobar"}
+	_, str := re.Repository()
+	if str != "foobar" {
+		t.Errorf("Something went wrong: %s", str)
+	}
+}
+
+// If we don't assign a string value to 'repository', we get whatever the
+// current git repository is called
+func TestRepoEnvironmentDefaultRepository(t *testing.T) {
+	re := RepoEnvironment{}
+	_, str := re.Repository()
+	if str != "cloud-platform-cli" {
+		t.Errorf("Expected cloud-platform-cli, got: x%sx", str)
+	}
+}

--- a/pkg/environment/repoEnvironment_test.go
+++ b/pkg/environment/repoEnvironment_test.go
@@ -11,6 +11,7 @@ func TestRequireCpEnvRepo(t *testing.T) {
 		t.Errorf("This should have passed")
 	}
 
+	// Fail if we're not in the CP-env repo (which we're not)
 	re = RepoEnvironment{}
 	err := re.MustBeInCloudPlatformEnvironments()
 	if err == nil {

--- a/pkg/environment/templateEnvironment.go
+++ b/pkg/environment/templateEnvironment.go
@@ -12,6 +12,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// all yaml and terraform templates will be pulled from URL endpoints below here
+const templatesBaseUrl = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/main/namespace-resources-cli-template"
+
 type templateEnvironment struct {
 	IsProduction          bool
 	Namespace             string

--- a/pkg/environment/templateEnvironment_test.go
+++ b/pkg/environment/templateEnvironment_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestRunningOutsideEnvironmentsWorkingCopy(t *testing.T) {
-	var err = CreateTemplateNamespace(nil, nil)
+	err := CreateTemplateNamespace(nil, nil)
 	if err.Error() != "You are outside cloud-platform-environment repo" {
 		t.Errorf("Unexpected error: %s", err)
 	}

--- a/pkg/environment/templatesRds.go
+++ b/pkg/environment/templatesRds.go
@@ -56,11 +56,6 @@ func templateRdsSetValues() (*templateRds, error) {
 		return nil, err
 	}
 
-	err = metadata.getNamespaceFromPath()
-	if err != nil {
-		return nil, err
-	}
-
 	namespace := Namespace{}
 	namespace.ReadYamlFile("00-namespace.yaml")
 

--- a/pkg/environment/templatesRds.go
+++ b/pkg/environment/templatesRds.go
@@ -67,18 +67,16 @@ func templateRdsSetValues() (*templateRds, error) {
 		return nil, err
 	}
 
-	err = metadata.getNamespaceMetadata()
-	if err != nil {
-		return nil, err
-	}
+	namespace := Namespace{}
+	namespace.ReadYamlFile("00-namespace.yaml")
 
-	values.Application = metadata.application
-	values.Namespace = metadata.namespace
-	values.BusinessUnit = metadata.businessUnit
-	values.EnvironmentName = metadata.environmentName
-	values.IsProduction, _ = strconv.ParseBool(metadata.isProduction)
+	values.Application = namespace.application
+	values.Namespace = namespace.name
+	values.BusinessUnit = namespace.businessUnit
+	values.EnvironmentName = namespace.environmentName
+	values.IsProduction, _ = strconv.ParseBool(namespace.isProduction)
 	values.RdsModuleName = "rds"
-	values.InfrastructureSupport = metadata.ownerEmail
+	values.InfrastructureSupport = namespace.ownerEmail
 	values.TeamName = "teamName"
 
 	return &values, nil

--- a/pkg/environment/templatesRds.go
+++ b/pkg/environment/templatesRds.go
@@ -20,6 +20,8 @@ type templateRds struct {
 	TeamName              string
 }
 
+const RdsTfFile = "resources/rds.tf"
+
 // CreateTemplateRds creates the terraform files from environment's template folder
 func CreateTemplateRds(cmd *cobra.Command, args []string) error {
 
@@ -35,13 +37,13 @@ func CreateTemplateRds(cmd *cobra.Command, args []string) error {
 
 	tpl := template.Must(template.New("rds").Parse(RdsTemplate))
 
-	f, _ := outputFileWriter("resources/rds.tf")
+	f, _ := outputFileWriter(RdsTfFile)
 	err = tpl.Execute(f, rdsValues)
 	if err != nil {
 		return (err)
 	}
 
-	fmt.Printf("RDS File generated in %s/%s/resources/rds.tf\n", namespaceBaseFolder, rdsValues.Namespace)
+	fmt.Printf("RDS File generated in %s\n", RdsTfFile)
 	color.Info.Tips("This template is using default values provided by your namespace information. Please review before raising PR")
 
 	return nil

--- a/pkg/environment/templatesRds.go
+++ b/pkg/environment/templatesRds.go
@@ -61,11 +61,6 @@ func templateRdsSetValues() (*templateRds, error) {
 		return nil, err
 	}
 
-	err = metadata.checkNamespaceExist()
-	if err != nil {
-		return nil, err
-	}
-
 	namespace := Namespace{}
 	namespace.ReadYamlFile("00-namespace.yaml")
 

--- a/pkg/environment/templatesRds.go
+++ b/pkg/environment/templatesRds.go
@@ -20,13 +20,13 @@ type templateRds struct {
 	TeamName              string
 }
 
-const RdsTemplateFile = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-terraform-rds-instance/main/template/rds.tmpl"
-const RdsTfFile = "resources/rds.tf"
+const rdsTemplateFile = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-terraform-rds-instance/main/template/rds.tmpl"
+const rdsTfFile = "resources/rds.tf"
 
 // CreateTemplateRds creates the terraform files from environment's template folder
 func CreateTemplateRds(cmd *cobra.Command, args []string) error {
 
-	RdsTemplate, err := downloadTemplate(RdsTemplateFile)
+	RdsTemplate, err := downloadTemplate(rdsTemplateFile)
 	if err != nil {
 		return (err)
 	}
@@ -38,13 +38,13 @@ func CreateTemplateRds(cmd *cobra.Command, args []string) error {
 
 	tpl := template.Must(template.New("rds").Parse(RdsTemplate))
 
-	f, _ := outputFileWriter(RdsTfFile)
+	f, _ := outputFileWriter(rdsTfFile)
 	err = tpl.Execute(f, rdsValues)
 	if err != nil {
 		return (err)
 	}
 
-	fmt.Printf("RDS File generated in %s\n", RdsTfFile)
+	fmt.Printf("RDS File generated in %s\n", rdsTfFile)
 	color.Info.Tips("This template is using default values provided by your namespace information. Please review before raising PR")
 
 	return nil
@@ -54,13 +54,13 @@ func templateRdsSetValues() (*templateRds, error) {
 	values := templateRds{}
 
 	re := RepoEnvironment{}
-	err := re.MustBeInCloudPlatformEnvironments()
+	err := re.mustBeInCloudPlatformEnvironments()
 	if err != nil {
 		return nil, err
 	}
 
 	ns := Namespace{}
-	err = ns.ReadYaml()
+	err = ns.readYaml()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/environment/templatesRds.go
+++ b/pkg/environment/templatesRds.go
@@ -57,7 +57,7 @@ func templateRdsSetValues() (*templateRds, error) {
 	}
 
 	namespace := Namespace{}
-	namespace.ReadYamlFile("00-namespace.yaml")
+	namespace.ReadYaml()
 
 	values.Application = namespace.application
 	values.Namespace = namespace.name

--- a/pkg/environment/templatesRds.go
+++ b/pkg/environment/templatesRds.go
@@ -35,8 +35,7 @@ func CreateTemplateRds(cmd *cobra.Command, args []string) error {
 
 	tpl := template.Must(template.New("rds").Parse(RdsTemplate))
 
-	outputPath := fmt.Sprintf("%s/%s/resources/rds.tf", namespaceBaseFolder, rdsValues.Namespace)
-	f, _ := outputFileWriter(outputPath)
+	f, _ := outputFileWriter("resources/rds.tf")
 	err = tpl.Execute(f, rdsValues)
 	if err != nil {
 		return (err)

--- a/pkg/environment/templatesRds.go
+++ b/pkg/environment/templatesRds.go
@@ -20,12 +20,13 @@ type templateRds struct {
 	TeamName              string
 }
 
+const RdsTemplateFile = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-terraform-rds-instance/main/template/rds.tmpl"
 const RdsTfFile = "resources/rds.tf"
 
 // CreateTemplateRds creates the terraform files from environment's template folder
 func CreateTemplateRds(cmd *cobra.Command, args []string) error {
 
-	RdsTemplate, err := downloadTemplate("https://raw.githubusercontent.com/ministryofjustice/cloud-platform-terraform-rds-instance/main/template/rds.tmpl")
+	RdsTemplate, err := downloadTemplate(RdsTemplateFile)
 	if err != nil {
 		return (err)
 	}

--- a/pkg/environment/templatesRds.go
+++ b/pkg/environment/templatesRds.go
@@ -52,9 +52,9 @@ func CreateTemplateRds(cmd *cobra.Command, args []string) error {
 
 func templateRdsSetValues() (*templateRds, error) {
 	values := templateRds{}
-	metadata := metadataFromNamespace{}
 
-	_, err := metadata.checkPath()
+	re := RepoEnvironment{}
+	err := re.MustBeInCloudPlatformEnvironments()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/environment/templatesRds.go
+++ b/pkg/environment/templatesRds.go
@@ -59,16 +59,16 @@ func templateRdsSetValues() (*templateRds, error) {
 		return nil, err
 	}
 
-	namespace := Namespace{}
-	namespace.ReadYaml()
+	ns := Namespace{}
+	ns.ReadYaml()
 
-	values.Application = namespace.application
-	values.Namespace = namespace.name
-	values.BusinessUnit = namespace.businessUnit
-	values.EnvironmentName = namespace.environmentName
-	values.IsProduction, _ = strconv.ParseBool(namespace.isProduction)
+	values.Application = ns.application
+	values.Namespace = ns.name
+	values.BusinessUnit = ns.businessUnit
+	values.EnvironmentName = ns.environmentName
+	values.IsProduction, _ = strconv.ParseBool(ns.isProduction)
 	values.RdsModuleName = "rds"
-	values.InfrastructureSupport = namespace.ownerEmail
+	values.InfrastructureSupport = ns.ownerEmail
 	values.TeamName = "teamName"
 
 	return &values, nil

--- a/pkg/environment/templatesRds.go
+++ b/pkg/environment/templatesRds.go
@@ -60,7 +60,10 @@ func templateRdsSetValues() (*templateRds, error) {
 	}
 
 	ns := Namespace{}
-	ns.ReadYaml()
+	err = ns.ReadYaml()
+	if err != nil {
+		return nil, err
+	}
 
 	values.Application = ns.application
 	values.Namespace = ns.name


### PR DESCRIPTION
This PR mainly moves existing functionality into different, more tightly-scoped, files. This should make it easier to maintain the code as we extend the cli tool. It also:

* adds basic tests for the new files
* uses constants instead of hard-coded string values
* uses relative rather than absolute file paths, where possible (to make testing easier)
* changes some function names for clarity