### PR TITLE
Add explicit build instructions for all platforms

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v1
         with:
           version: latest
-          args: release --rm-dist
+          args: release --rm-dist --release-notes=CHANGELOG.md
           workdir: ./cmd/cloud-platform
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -23,7 +23,7 @@ jobs:
         id: go
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@master
+        uses: goreleaser/goreleaser-action@v1
         with:
           version: latest
           args: release --rm-dist

--- a/cmd/cloud-platform/.goreleaser.yml
+++ b/cmd/cloud-platform/.goreleaser.yml
@@ -1,4 +1,15 @@
 builds:
-  -
-    id: build
-    binary: cloud-platform
+  - <<: &build_defaults
+      binary: cloud-platform
+      main: ./cmd/cloud-platform
+    id: macos
+    goos: [darwin]
+    goarch: [amd64]
+  - <<: *build_defaults
+    id: linux
+    goos: [linux]
+    goarch: [386, amd64, arm64]
+  - <<: *build_defaults
+    id: windows
+    goos: [windows]
+    goarch: [386, amd64]


### PR DESCRIPTION
This adds a windows build, which was missing before

co-authored with @mogaal