### PR TITLE
Revert "Add CHANGELOG to release package"

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v1
         with:
           version: latest
-          args: release --rm-dist --release-notes=CHANGELOG.md
+          args: release --rm-dist
           workdir: ./cmd/cloud-platform
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This reverts commit 91c2736d90f5134b64432ed8a70029508c1fad62.

This didn't work, and it broke the release process. But even without it,
we get a "Changelog" in the release description, which is good enough
for now.