### PR TITLE
Stop building & testing a windows version

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/cmd/cloud-platform/.goreleaser.yml
+++ b/cmd/cloud-platform/.goreleaser.yml
@@ -8,7 +8,3 @@ builds:
     id: linux
     goos: [linux]
     goarch: [386, amd64, arm64]
-  - <<: *build_defaults
-    id: windows
-    goos: [windows]
-    goarch: [386, amd64]


### PR DESCRIPTION
As far as we know, we have no windows users, so
the extra overhead of maintaining working tests
and builds for windows is wasted.

This change removes the windows platform (we can
put it back again if we ever need it)