### PR TITLE
Add "Create S3" command to cloud-platform  cli

### DIFF
--- a/pkg/commands/environment.go
+++ b/pkg/commands/environment.go
@@ -13,10 +13,12 @@ func addEnvironmentCmd(topLevel *cobra.Command) {
 	topLevel.AddCommand(environmentCmd)
 	environmentCmd.AddCommand(environmentEcrCmd)
 	environmentCmd.AddCommand(environmentRdsCmd)
+	environmentCmd.AddCommand(environmentS3Cmd)
 	environmentCmd.AddCommand(environmentSvcCmd)
 	environmentCmd.AddCommand(environmentCreateCmd)
 	environmentEcrCmd.AddCommand(environmentEcrCreateCmd)
 	environmentRdsCmd.AddCommand(environmentRdsCreateCmd)
+	environmentS3Cmd.AddCommand(environmentS3CreateCmd)
 	environmentSvcCmd.AddCommand(environmentSvcCreateCmd)
 	environmentSvcCreateCmd.Flags().StringP("name", "n", "cloud-platform-user", "The name of the ServiceAccount resource")
 
@@ -68,6 +70,22 @@ var environmentRdsCreateCmd = &cobra.Command{
 	Short:  `Create "resources/rds.tf" terraform file for an RDS instance`,
 	PreRun: upgradeIfNotLatest,
 	RunE:   environment.CreateTemplateRds,
+}
+
+var environmentS3Cmd = &cobra.Command{
+	Use:   "s3",
+	Short: `Add a S3 bucket to a namespace`,
+	Example: heredoc.Doc(`
+	$ cloud-platform environment s3 create
+	`),
+	PreRun: upgradeIfNotLatest,
+}
+
+var environmentS3CreateCmd = &cobra.Command{
+	Use:    "create",
+	Short:  `Create "resources/s3.tf" terraform file for a S3 bucket`,
+	PreRun: upgradeIfNotLatest,
+	RunE:   environment.CreateTemplateS3,
 }
 
 var environmentSvcCmd = &cobra.Command{

--- a/pkg/environment/templatesS3.go
+++ b/pkg/environment/templatesS3.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const s3TemplateFile = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-terraform-s3-bucket/add-tmpl/template/s3.tmpl"
+const s3TemplateFile = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-terraform-s3-bucket/main/template/s3.tmpl"
 const s3TfFile = "resources/s3.tf"
 
 // CreateTemplateRds creates the terraform files from environment's template folder

--- a/pkg/environment/templatesS3.go
+++ b/pkg/environment/templatesS3.go
@@ -1,0 +1,51 @@
+package environment
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gookit/color"
+	"github.com/spf13/cobra"
+)
+
+const s3TemplateFile = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-terraform-s3-bucket/add-tmpl/template/s3.tmpl"
+const s3TfFile = "resources/s3.tf"
+
+// CreateTemplateRds creates the terraform files from environment's template folder
+func CreateTemplateS3(cmd *cobra.Command, args []string) error {
+	re := RepoEnvironment{}
+	err := re.mustBeInANamespaceFolder()
+	if err != nil {
+		return err
+	}
+
+	err = createS3TfFile()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("S3 File generated in %s\n", s3TfFile)
+	color.Info.Tips("This template is using default values provided by your namespace information. Please review before raising PR")
+
+	return nil
+}
+
+//------------------------------------------------------------------------------
+
+func createS3TfFile() error {
+	// The s3 "template" is actually an example file that we can just save
+	// "as is" into the user's resources/ directory as `s3.tf`
+	s3Template, err := downloadTemplate(s3TemplateFile)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Create(s3TfFile)
+	if err != nil {
+		return err
+	}
+	f.WriteString(s3Template)
+	f.Close()
+
+	return nil
+}

--- a/pkg/environment/templatesS3_test.go
+++ b/pkg/environment/templatesS3_test.go
@@ -1,0 +1,22 @@
+package environment
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCreatesS3TfFile(t *testing.T) {
+	filename := "resources/s3.tf"
+	os.Mkdir("resources", 0755)
+
+	err := createS3TfFile()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+
+	moduleName := "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket"
+	fileContainsString(t, filename, moduleName)
+
+	os.Remove(filename)
+	os.Remove("resources")
+}


### PR DESCRIPTION
This PR adds "environment s3 create". 
This feature will allow users to create a standard s3 bucket to use within their namespace using the cloud-platform cli.

This PR also contains a test file to simulate and check the functionality of the createFile function.