### PR TITLE
Store lower-case team name, when creating NS

### DIFF
--- a/pkg/environment/templateEnvironment.go
+++ b/pkg/environment/templateEnvironment.go
@@ -3,6 +3,7 @@ package environment
 import (
 	"fmt"
 	"os"
+	"strings"
 	"text/template"
 
 	"github.com/gookit/color"
@@ -135,7 +136,7 @@ func promptUserForNamespaceValues() (*Namespace, error) {
 	values.Application = Application.value
 	values.BusinessUnit = businessUnit.value
 	values.Namespace = Namespace.value
-	values.GithubTeam = GithubTeam.value
+	values.GithubTeam = strings.ToLower(GithubTeam.value)
 	values.Environment = Environment.value
 	values.IsProduction = IsProduction.value
 	values.SlackChannel = SlackChannel.value

--- a/pkg/environment/templateEnvironment_test.go
+++ b/pkg/environment/templateEnvironment_test.go
@@ -62,6 +62,7 @@ func TestCreateNamespace(t *testing.T) {
 		namespaceFile:   "cloud-platform.justice.gov.uk/is-production: \"false\"",
 		rbacFile:        "name: \"github:my-github-team\"",
 		variablesTfFile: "my-team-slack-channel",
+		variablesTfFile: "my-github-team",
 	}
 
 	for filename, searchString := range stringsInFiles {


### PR DESCRIPTION
This change causes the team name to be lower-cased
before we write the rbac.yaml and variables.tf
files.

This fixes a problem later on, when the user tries
to create an ECR - if they have upper-case letters
in their team name, the ECR name generated by our
terraform module will be rejected.

NB: This change is not tested by the unit tests, 
since those don't cover the relevant part of the
code.