### PR TITLE
Remove ingress creation from environment create command

### DIFF
--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -12,7 +12,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.4.14"
+var Version = "1.4.15"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"

--- a/pkg/environment/templateEnvironment.go
+++ b/pkg/environment/templateEnvironment.go
@@ -196,10 +196,6 @@ func downloadAndInitialiseTemplates(namespace string) (error, []*templateFromUrl
 			name: "resources/variables.tf",
 			url:  envTemplateLocation + "/" + "resources/variables.tf",
 		},
-		{
-			name: "resources/ingress.tf",
-			url:  envTemplateLocation + "/" + "resources/ingress.tf",
-		},
 	}
 
 	err := downloadTemplateContents(templates)

--- a/pkg/environment/templateEnvironment_test.go
+++ b/pkg/environment/templateEnvironment_test.go
@@ -34,7 +34,6 @@ func TestCreateNamespace(t *testing.T) {
 	namespaceFile := dir + "00-namespace.yaml"
 	rbacFile := dir + "01-rbac.yaml"
 	variablesTfFile := dir + "resources/variables.tf"
-	ingressTfFile := dir + "resources/ingress.tf"
 
 	filenames := []string{
 		namespaceFile,
@@ -45,7 +44,6 @@ func TestCreateNamespace(t *testing.T) {
 		dir + "resources/main.tf",
 		variablesTfFile,
 		dir + "resources/versions.tf",
-		ingressTfFile,
 	}
 
 	for _, f := range filenames {
@@ -65,7 +63,6 @@ func TestCreateNamespace(t *testing.T) {
 		rbacFile:        "name: \"github:my-github-team\"",
 		variablesTfFile: "my-team-slack-channel",
 		variablesTfFile: "my-github-team",
-		ingressTfFile:   `namespace = "foobar"`,
 	}
 
 	for filename, searchString := range stringsInFiles {


### PR DESCRIPTION
Due to the hard AWS limit creating an ingress controller per namespace
is no longer viable. This commit removes the creation of an ingress.tf
file.