### PR TITLE
Add `export GO111MODULE=on`

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,6 +3,7 @@ DIRS_WITH_TESTS := $(shell find * -type f -name '*_test.go' | xargs -n 1 dirname
 DIRS_WITH_GOFILES := $(shell find * -type f -name '*.go' | xargs -n 1 dirname | sort | uniq)
 
 cloud-platform: $(SOURCE_FILES)
+	export GO111MODULE=on
 	go mod download
 	go build -o cloud-platform ./cmd/cloud-platform/main.go
 


### PR DESCRIPTION
Without this,`go mod download` can result in errors like:

```
github.com/hashicorp/hcl/hcl/parser
../../go/pkg/mod/github.com/hashicorp/hcl@v1.0.0/decoder.go:12:2: module github.com/hashicorp/hcl@latest found (v1.0.0), but does not contain package github.com/hashicorp/hcl/hcl/parser
../../go/pkg/mod/github.com/spf13/viper@v1.6.1/viper.go:39:2: module github.com/hashicorp/hcl@latest found (v1.0.0), but does not contain package github.com/hashicorp/hcl/hcl/printer
../../go/pkg/mod/github.com/hashicorp/hcl@v1.0.0/hcl/ast/ast.go:9:2: module github.com/hashicorp/hcl@latest found (v1.0.0), but does not contain package github.com/hashicorp/hcl/hcl/token
make: *** [cloud-platform] Error 1
```