### PR TITLE
🐛 allow underscore in slack regex

### DIFF
--- a/pkg/environment/slackChannelValidator.go
+++ b/pkg/environment/slackChannelValidator.go
@@ -5,6 +5,6 @@ type slackChannelValidator struct {
 
 func (v *slackChannelValidator) isValid(s string) bool {
 	r := new(regexValidator)
-	r.regex = `^[a-z\-]+$`
+	r.regex = `^[a-z\-_]+$`
 	return r.isValid(s)
 }

--- a/pkg/environment/templateEnvironment_test.go
+++ b/pkg/environment/templateEnvironment_test.go
@@ -24,7 +24,7 @@ func TestCreateNamespace(t *testing.T) {
 		InfrastructureSupport: "some-team@digital.justice.gov.uk",
 		SourceCode:            "https://github.com/ministryofjustice/somerepo",
 		GithubTeam:            "my-github-team",
-		SlackChannel:          "my-team-slack-channel",
+		SlackChannel:          "my-team-slack_channel",
 		IsProduction:          "false",
 	}
 
@@ -61,7 +61,7 @@ func TestCreateNamespace(t *testing.T) {
 		namespaceFile:   "cloud-platform.justice.gov.uk/source-code: \"https://github.com/ministryofjustice/somerepo\"",
 		namespaceFile:   "cloud-platform.justice.gov.uk/is-production: \"false\"",
 		rbacFile:        "name: \"github:my-github-team\"",
-		variablesTfFile: "my-team-slack-channel",
+		variablesTfFile: "my-team-slack_channel",
 		variablesTfFile: "my-github-team",
 	}
 


### PR DESCRIPTION
**Changes**
- allow for slack channel values to have underscores

NB: I'm not familiar with go, but attempted to change a value in the tests to verify this. This may want breaking into its own test