### PR TITLE
Fix Dockerfile, helm is not found anymore in this URL. Copied line from tools-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,8 @@ RUN git clone https://github.com/AGWA/git-crypt.git \
 RUN curl -sLo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl
 
 # Install helm
-RUN curl -sL https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar -xzC /usr/local/bin --strip-components 1 linux-amd64/helm
+RUN curl -L https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helm && rm -rf linux-amd64
+
 
 # Install terraform
 RUN curl -sL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | unzip -d /usr/local/bin -

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,6 @@ RUN curl -sLo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-r
 # Install helm
 RUN curl -L https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helm && rm -rf linux-amd64
 
-
 # Install terraform
 RUN curl -sL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | unzip -d /usr/local/bin -
 


### PR DESCRIPTION
 Helm is not found anymore in this URL, therefore the Docker Build is failing.

Copied Helm install from tools image and just tested it builds:

```
Removing intermediate container 577fe3c647d7
 ---> 66e99515756b
Successfully built 66e99515756b
Successfully tagged test:latest
```