### PR TITLE
Added Bulk apply capability

### DIFF
--- a/pkg/commands/terraform.go
+++ b/pkg/commands/terraform.go
@@ -43,11 +43,19 @@ func addTerraformCmd(topLevel *cobra.Command) {
 		Run: func(cmd *cobra.Command, args []string) {
 			contextLogger := log.WithFields(log.Fields{"subcommand": "apply"})
 
-			contextLogger.Info("Executing terraform apply")
-			err := options.Apply()
+			if options.BulkTfPaths == "" {
+				contextLogger.Info("Executing terraform apply")
+				err := options.Apply()
+				if err != nil {
+					contextLogger.Fatal("Error executing terraform apply - check the outputs")
+				}
+			} else {
+				err := options.BulkApply()
 
-			if err != nil {
-				contextLogger.Fatal("Error executing terraform apply - check the outputs")
+				if err != nil {
+					contextLogger.Fatal(err)
+				}
+
 			}
 		},
 	}
@@ -59,7 +67,7 @@ func addTerraformCmd(topLevel *cobra.Command) {
 		Run: func(cmd *cobra.Command, args []string) {
 			contextLogger := log.WithFields(log.Fields{"subcommand": "plan"})
 
-			if options.BulkTfPlanPaths == "" {
+			if options.BulkTfPaths == "" {
 				contextLogger.Info("Executing terraform plan")
 				err := options.Plan()
 
@@ -96,7 +104,7 @@ func addCommonFlags(cmd *cobra.Command, o *terraform.Commander) {
 	cmd.PersistentFlags().StringVarP(&o.Workspace, "workspace", "w", "default", "Default workspace where terraform is going to be executed")
 	cmd.PersistentFlags().BoolVarP(&o.DisplayTfOutput, "display-tf-output", "d", true, "Display or not terraform plan output")
 	cmd.PersistentFlags().StringVarP(&o.VarFile, "var-file", "v", "", "tfvar to be used by terraform")
-	cmd.PersistentFlags().StringVar(&o.BulkTfPlanPaths, "dirs-file", "", "Required for bulk-plans, file path which holds directories where terraform plan is going to be executed")
+	cmd.PersistentFlags().StringVar(&o.BulkTfPaths, "dirs-file", "", "Required for bulk-plans, file path which holds directories where terraform plan is going to be executed")
 
 	cmd.MarkPersistentFlagRequired("aws-access-key-id")
 	cmd.MarkPersistentFlagRequired("aws-secret-access-key")

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -196,7 +196,7 @@ func (s *Commander) Apply() error {
 	}
 
 	if s.DisplayTfOutput {
-		fmt.Println(output.Stdout)
+		output.redacted()
 	}
 
 	if output.ExitCode == 0 {


### PR DESCRIPTION
- Renamed BulkTfPlanPaths to `BulkTfPlanPaths`. From now on, it doesn't apply for `Plan` but also `Apply`
- **Added BulkApply**. It was also possible to reuse the same BulkPlan function using the same function and passing an argument with the action (plan or apply). I decided to split it to keep it simple and also to be able to customise [1] each of them individually without adding complicated logic. This can be changed in the future. 

[1] Here customize might means: 
 - I want to show the terraform init output for apply but not for plan. 
 - I don't want to "cut" the refresh state output for apply (only for plan)
- etc