### PR TITLE
Set version to 1.6.2

### DIFF
--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -12,7 +12,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.6.0"
+var Version = "1.6.2"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"


### PR DESCRIPTION
The current release is 1.6.1, but the code specifies 1.6.0. This means
users cannot use the cli tool because it goes into an endless upgrade
loop.

This change sets the version to 1.6.2, and a release with that version
will be created as soon as this change is merged.
