### PR TITLE
Fixed in divergence output bug

### DIFF
--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -12,7 +12,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.6.3"
+var Version = "1.6.4"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -144,10 +144,8 @@ func (s *Commander) CheckDivergence() error {
 	)
 
 	output, err := s.Terraform(arg...)
-
 	if err != nil {
-		log.Error(err)
-		log.Error(output.Stderr)
+		return err
 	}
 
 	if s.DisplayTfOutput {


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x7c1c08]

goroutine 1 [running]:
github.com/ministryofjustice/cloud-platform-cli/pkg/terraform.(*Commander).CheckDivergence(0xc0000ce2c0, 0xc000000004, 0xc00011fbc8)
	/build/pkg/terraform/terraform.go:150 +0x208
github.com/ministryofjustice/cloud-platform-cli/pkg/commands.addTerraformCmd.func1(0xc000120a00, 0xc00009cc60, 0x0, 0x2)
	/build/pkg/commands/terraform.go:31 +0x15a
github.com/spf13/cobra.(*Command).execute(0xc000120a00, 0xc00009cc20, 0x2, 0x2, 0xc000120a00, 0xc00009cc20)
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830 +0x2aa
github.com/spf13/cobra.(*Command).ExecuteC(0xc000120500, 0xc000120500, 0x43b3da, 0xcf8840)
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
	/build/cmd/cloud-platform/main.go:22 +0x9f
```

Seen within the divergence pipeline