### PR TITLE
Add feature - decode k8s secrets

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -6,12 +6,12 @@ on:
 
 jobs:
   run-scan:
-    name: Sonarqube Scan 
+    name: Sonarqube Scan
     runs-on: ubuntu-latest
 
     steps:
       - name: Setup sonarqube
-        uses: warchant/setup-sonar-scanner@v1
+        uses: warchant/setup-sonar-scanner@v3
 
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -10,4 +10,5 @@ func AddCommands(topLevel *cobra.Command) {
 	addKubecfgCmd(topLevel)
 	addVersion(topLevel)
 	addEnvironmentCmd(topLevel)
+	addDecodeSecret(topLevel)
 }

--- a/pkg/commands/decodeSecret.go
+++ b/pkg/commands/decodeSecret.go
@@ -1,0 +1,31 @@
+package commands
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	decodeSecret "github.com/ministryofjustice/cloud-platform-cli/pkg/decodeSecret"
+	"github.com/spf13/cobra"
+)
+
+func addDecodeSecret(topLevel *cobra.Command) {
+	opts := &decodeSecret.DecodeSecretOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "decode-secret",
+		Short: `Decode a kubernetes secret`,
+		Example: heredoc.Doc(`
+$ cloud-platform decode-secret -n mynamespace -s mysecret
+	`),
+		PreRun: upgradeIfNotLatest,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return decodeSecret.DecodeSecret(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Secret, "secret", "s", "", "Secret name")
+	cmd.MarkFlagRequired("secret")
+
+	cmd.Flags().StringVarP(&opts.Namespace, "namespace", "n", "", "Namespace name")
+	cmd.MarkFlagRequired("namespace")
+
+	topLevel.AddCommand(cmd)
+}

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -12,7 +12,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.6.4"
+var Version = "1.6.5"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"

--- a/pkg/decodeSecret/decodeSecret.go
+++ b/pkg/decodeSecret/decodeSecret.go
@@ -13,11 +13,6 @@ type DecodeSecretOptions struct {
 	Namespace string
 }
 
-type SecretData struct {
-	Key   string
-	Value string
-}
-
 func DecodeSecret(opts *DecodeSecretOptions) error {
 	jsn := retrieveSecret(opts.Namespace, opts.Secret)
 

--- a/pkg/decodeSecret/decodeSecret.go
+++ b/pkg/decodeSecret/decodeSecret.go
@@ -30,6 +30,21 @@ func DecodeSecret(opts *DecodeSecretOptions) error {
 	return nil
 }
 
+func retrieveSecret(namespace, secret string) string {
+	cmd := exec.Command("kubectl", "--namespace", namespace, "get", "secret", secret, "-o", "json")
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println("Error: ", err)
+		return ""
+	}
+
+	return out.String()
+}
+
 func (sd *secretDecoder) processJson(jsn string) (error, string) {
 	if jsn == "" {
 		return errors.New("failed to retrieve secret from namespace"), ""
@@ -51,21 +66,6 @@ func (sd *secretDecoder) processJson(jsn string) (error, string) {
 	}
 
 	return nil, str
-}
-
-func retrieveSecret(namespace, secret string) string {
-	cmd := exec.Command("kubectl", "--namespace", namespace, "get", "secret", secret, "-o", "json")
-
-	var out bytes.Buffer
-	cmd.Stdout = &out
-
-	err := cmd.Run()
-	if err != nil {
-		fmt.Println("Error: ", err)
-		return ""
-	}
-
-	return out.String()
 }
 
 func decodeKeys(data map[string]interface{}) error {

--- a/pkg/decodeSecret/decodeSecret.go
+++ b/pkg/decodeSecret/decodeSecret.go
@@ -21,6 +21,17 @@ type SecretData struct {
 func DecodeSecret(opts *DecodeSecretOptions) error {
 	jsn := retrieveSecret(opts.Namespace, opts.Secret)
 
+	err, str := processJson(jsn)
+	if err != nil {
+		fmt.Println("Error: ", err)
+		return err
+	}
+
+	fmt.Printf(str)
+	return nil
+}
+
+func processJson(jsn string) (error, string) {
 	var result map[string]interface{}
 	json.Unmarshal([]byte(jsn), &result)
 
@@ -28,12 +39,15 @@ func DecodeSecret(opts *DecodeSecretOptions) error {
 
 	err := decodeKeys(data)
 	if err != nil {
-		fmt.Println("Error: ", err)
-		return err
+		return err, ""
 	}
 
-	prettyPrint(result)
-	return nil
+	err, str := formatJson(result)
+	if err != nil {
+		return err, ""
+	}
+
+	return nil, str
 }
 
 func retrieveSecret(namespace, secret string) string {
@@ -67,18 +81,16 @@ func base64decode(i interface{}) string {
 	str, e := base64.StdEncoding.DecodeString(i.(string))
 	if e != nil {
 		fmt.Println(e)
-		return ""
+		return "ERROR: base64 decode failed"
 	}
 	return fmt.Sprintf("%s", str)
 }
 
-func prettyPrint(result map[string]interface{}) error {
+func formatJson(result map[string]interface{}) (error, string) {
 	str, err := json.MarshalIndent(result, "", "    ")
 	if err != nil {
-		fmt.Println("Error: ", err)
-		return err
+		return err, ""
 	}
 
-	fmt.Printf("%s\n", str)
-	return nil
+	return nil, fmt.Sprintf("%s\n", str)
 }

--- a/pkg/decodeSecret/decodeSecret.go
+++ b/pkg/decodeSecret/decodeSecret.go
@@ -1,0 +1,17 @@
+package decodeSecret
+
+import (
+	"fmt"
+)
+
+type DecodeSecretOptions struct {
+	Secret    string
+	Namespace string
+}
+
+func DecodeSecret(opts *DecodeSecretOptions) error {
+	fmt.Println("Hello from DecodeSecret")
+	fmt.Println(opts.Namespace)
+	fmt.Println(opts.Secret)
+	return nil
+}

--- a/pkg/decodeSecret/decodeSecret.go
+++ b/pkg/decodeSecret/decodeSecret.go
@@ -1,7 +1,11 @@
 package decodeSecret
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"os/exec"
 )
 
 type DecodeSecretOptions struct {
@@ -9,9 +13,72 @@ type DecodeSecretOptions struct {
 	Namespace string
 }
 
+type SecretData struct {
+	Key   string
+	Value string
+}
+
 func DecodeSecret(opts *DecodeSecretOptions) error {
-	fmt.Println("Hello from DecodeSecret")
-	fmt.Println(opts.Namespace)
-	fmt.Println(opts.Secret)
+	jsn := retrieveSecret(opts.Namespace, opts.Secret)
+
+	var result map[string]interface{}
+	json.Unmarshal([]byte(jsn), &result)
+
+	data := result["data"].(map[string]interface{})
+
+	err := decodeKeys(data)
+	if err != nil {
+		fmt.Println("Error: ", err)
+		return err
+	}
+
+	prettyPrint(result)
+	return nil
+}
+
+func retrieveSecret(namespace, secret string) string {
+	cmd := exec.Command("kubectl", "--namespace", namespace, "get", "secret", secret, "-o", "json")
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println("Error: ", err)
+		return ""
+	}
+
+	return out.String()
+}
+
+func decodeKeys(data map[string]interface{}) error {
+	for k, v := range data {
+		switch v.(type) {
+		case string:
+			data[k] = base64decode(v)
+		default:
+			return fmt.Errorf("Expected key %s of secret to be a string, but it wasn't\n", k)
+		}
+	}
+	return nil
+}
+
+func base64decode(i interface{}) string {
+	str, e := base64.StdEncoding.DecodeString(i.(string))
+	if e != nil {
+		fmt.Println(e)
+		return ""
+	}
+	return fmt.Sprintf("%s", str)
+}
+
+func prettyPrint(result map[string]interface{}) error {
+	str, err := json.MarshalIndent(result, "", "    ")
+	if err != nil {
+		fmt.Println("Error: ", err)
+		return err
+	}
+
+	fmt.Printf("%s\n", str)
 	return nil
 }

--- a/pkg/decodeSecret/decodeSecret_test.go
+++ b/pkg/decodeSecret/decodeSecret_test.go
@@ -1,0 +1,45 @@
+package decodeSecret
+
+import "testing"
+
+func TestDecodeSecret(t *testing.T) {
+	jsn := `{ "data": { "key1": "d2liYmxl", "key2": "d29iYmxl" } }`
+
+	expected := `{
+    "data": {
+        "key1": "wibble",
+        "key2": "wobble"
+    }
+}
+`
+	sd := secretDecoder{}
+	err, actual := sd.processJson(jsn)
+	if err != nil || actual != expected {
+		t.Errorf("Expected:\n%s\nGot:\n%s\n", expected, actual)
+	}
+}
+
+func TestBadBase64(t *testing.T) {
+	jsn := `{ "data": { "key1": "1", "key2": "2" } }`
+
+	expected := `{
+    "data": {
+        "key1": "ERROR: base64 decode failed",
+        "key2": "ERROR: base64 decode failed"
+    }
+}
+`
+	sd := secretDecoder{}
+	err, actual := sd.processJson(jsn)
+	if err != nil || actual != expected {
+		t.Errorf("Expected:\n%s\nGot:\n%s\n", expected, actual)
+	}
+}
+
+func TestNoSuchSecret(t *testing.T) {
+	sd := secretDecoder{}
+	err, _ := sd.processJson("")
+	if err == nil {
+		t.Errorf("Expected an error")
+	}
+}


### PR DESCRIPTION
This PR adds the ability to run:
```
cloud-platform decode-secret -n mynamespace -s secret
```
The output is a pretty-printed JSON representation of the secret, with the values of the data keys base64 decoded.
