### PR TITLE
Change GoReleaser config to inc Windows and changelog

### DIFF
--- a/cmd/cloud-platform/.goreleaser.yml
+++ b/cmd/cloud-platform/.goreleaser.yml
@@ -1,10 +1,25 @@
 builds:
-  - <<: &build_defaults
-      binary: cloud-platform
-    id: macos
-    goos: [darwin]
-    goarch: [amd64]
-  - <<: *build_defaults
-    id: linux
-    goos: [linux]
-    goarch: [386, amd64, arm64]
+- env:
+    - CGO_ENABLED=0
+  binary: cloud-platform
+  goos:
+    - linux
+    - darwin
+    - windows
+  goarch:
+    - 386
+    - amd64
+    - arm
+    - arm64
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  flags:
+    - -trimpath
+  ldflags:
+    - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{ .CommitDate }} -X main.builtBy=cloud-platform
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - Merge pull request
+    - Merge branch
+    - go mod tidy


### PR DESCRIPTION
I noticed the Linux binary wasn't working so I changed the structure of the GoReleaser config. This now also creates a Windows binary and will produce a changelog in the release.