### PR TITLE
Add `decode-secret ... -e` to export AWS creds

### DIFF
--- a/pkg/commands/decodeSecret.go
+++ b/pkg/commands/decodeSecret.go
@@ -27,5 +27,7 @@ $ cloud-platform decode-secret -n mynamespace -s mysecret
 	cmd.Flags().StringVarP(&opts.Namespace, "namespace", "n", "", "Namespace name")
 	cmd.MarkFlagRequired("namespace")
 
+	cmd.Flags().BoolVarP(&opts.ExportAwsCreds, "export-aws-credentials", "e", false, "Export AWS credentials as shell variables")
+
 	topLevel.AddCommand(cmd)
 }

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -12,7 +12,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.6.7"
+var Version = "1.7.0"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"

--- a/pkg/decodeSecret/decodeSecret_test.go
+++ b/pkg/decodeSecret/decodeSecret_test.go
@@ -43,3 +43,16 @@ func TestNoSuchSecret(t *testing.T) {
 		t.Errorf("Expected an error")
 	}
 }
+
+func TestRecordsAwsSecrets(t *testing.T) {
+	// jsn := `{ "data": { "access_key_id": "myaccesskey", "secret_access_key": "mysecretkey" } }`
+	jsn := `{ "data": { "access_key_id": "bXlhY2Nlc3NrZXk=", "secret_access_key": "bXlzZWNyZXRrZXk=" } }`
+	sd := secretDecoder{}
+	err, _ := sd.processJson(jsn)
+	if err != nil || sd.AccessKeyID != "myaccesskey" {
+		t.Errorf("Expected:\n%s\nGot:\n%s\n", "myaccesskey", sd.AccessKeyID)
+	}
+	if err != nil || sd.SecretAccessKey != "mysecretkey" {
+		t.Errorf("Expected:\n%s\nGot:\n%s\n", "mysecretkey", sd.SecretAccessKey)
+	}
+}


### PR DESCRIPTION
This allows the user to run commands like this:

```
eval $(cloud-platform decode-secret -n poornima-dev -s wplearndev-rds-output -e)
aws rds describe-db-instances --db-instance-identifier=cloud-platform-xxxxxxxx
```

i.e. it incorporates the functionality of [this gist](https://gist.github.com/digitalronin/542c001f9db4ced79ebc0f180d36b609) directly into the CLI tool