### PR TITLE
Enable `--skip-version-check` for pipeline use

### DIFF
--- a/cmd/cloud-platform/main.go
+++ b/cmd/cloud-platform/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	commands "github.com/ministryofjustice/cloud-platform-cli/pkg/commands"
 )
@@ -17,6 +18,15 @@ func main() {
 			cmd.Help()
 		},
 	}
+
+	// We need the option to bypass the automatic update process, so that new
+	// releases of the cloud-platform tool don't break any pipelines which use
+	// the tool. This allows us to add `--skip-version-check` to any command
+	// which runs in a pipeline.
+	var SkipVersionCheck bool
+	cmds.PersistentFlags().BoolVarP(&SkipVersionCheck, "skip-version-check", "", false, "don't check for updates")
+	viper.BindPFlag("skip-version-check", cmds.PersistentFlags().Lookup("skip-version-check"))
+
 	commands.AddCommands(cmds)
 
 	if err := cmds.Execute(); err != nil {

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -9,10 +9,11 @@ import (
 	release "github.com/ministryofjustice/cloud-platform-cli/pkg/github/release"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.7.0"
+var Version = "1.7.1"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"
@@ -46,6 +47,9 @@ func version() string {
 }
 
 func upgradeIfNotLatest(cmd *cobra.Command, args []string) {
+	if viper.GetBool("skip-version-check") {
+		return
+	}
 	r := release.New(owner, repoName, Version, binaryName)
 	r.UpgradeIfNotLatest()
 }


### PR DESCRIPTION
The automatic update feature of the CLI tool means
that all pipelines which use the tool will break
whenever a new version is released. 

This change allows us to add 
`--skip-version-check` to all pipeline commands, 
so that the pipeline runs correctly regardless of
any new releases of the CLI tool.

NB: Merging this change will break our pipelines
again, but hopefully for the last time.