### PR TITLE
Create serviceaccount via terraform

### DIFF
--- a/pkg/commands/environment.go
+++ b/pkg/commands/environment.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"strings"
-
 	environment "github.com/ministryofjustice/cloud-platform-cli/pkg/environment"
 
 	"github.com/MakeNowJust/heredoc"
@@ -20,8 +18,6 @@ func addEnvironmentCmd(topLevel *cobra.Command) {
 	environmentRdsCmd.AddCommand(environmentRdsCreateCmd)
 	environmentS3Cmd.AddCommand(environmentS3CreateCmd)
 	environmentSvcCmd.AddCommand(environmentSvcCreateCmd)
-	environmentSvcCreateCmd.Flags().StringP("name", "n", "cloud-platform-user", "The name of the ServiceAccount resource")
-
 }
 
 var environmentCmd = &cobra.Command{
@@ -105,12 +101,7 @@ var environmentSvcCreateCmd = &cobra.Command{
 	`),
 	PreRun: upgradeIfNotLatest,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		nameFlag, err := cmd.Flags().GetString("name")
-		if err != nil {
-			return err
-		}
-
-		if err = environment.CreateTemplateServiceAccount(strings.ToLower(nameFlag)); err != nil {
+		if err := environment.CreateTemplateServiceAccount(); err != nil {
 			return err
 		}
 

--- a/pkg/commands/environment.go
+++ b/pkg/commands/environment.go
@@ -92,7 +92,7 @@ var environmentSvcCmd = &cobra.Command{
 	Use:   "serviceaccount",
 	Short: `Add a serviceaccount to a namespace`,
 	Example: heredoc.Doc(`
-	$ cloud-platform environment serviceaccount 
+	$ cloud-platform environment serviceaccount
 	`),
 	PreRun: upgradeIfNotLatest,
 }

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -13,7 +13,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.7.1"
+var Version = "1.7.2"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"

--- a/pkg/environment/templateServiceaccount_test.go
+++ b/pkg/environment/templateServiceaccount_test.go
@@ -5,30 +5,18 @@ import (
 	"testing"
 )
 
-// TestCreateServiceAccountFiles simulates a ServiceAccount object
-// and tests whether the createSvcAccFile function creates a serviceaccount
-// manifest. To do this, the function requires there to be a namespace manifest
-// called 00-namespace.yaml
-func TestCreateServiceAccountFiles(t *testing.T) {
-	svc := ServiceAccount{
-		Namespace: "foobar",
-	}
+func TestCreateServiceAccountFile(t *testing.T) {
+	filename := "resources/serviceaccount.tf"
+	os.Mkdir("resources", 0755)
 
-	svcAccFileName := "05-serviceaccount.yaml"
-	svcAccNamespace := "00-namespace.yaml"
-
-	err := os.Link("fixtures/foobar-namespace.yml", svcAccNamespace)
-	if err != nil {
-		t.Error("Error copying file:", err)
-	}
-	err = svc.createSvcAccFile()
+	err := createSvcAccTfFile()
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
 
-	fileContainsString(t, svcAccFileName, "cloud-platform-user")
-	fileContainsString(t, svcAccFileName, svc.Namespace)
+	moduleName := "github.com/ministryofjustice/cloud-platform-terraform-serviceaccount"
+	fileContainsString(t, filename, moduleName)
 
-	os.Remove(svcAccFileName)
-	os.Remove(svcAccNamespace)
+	os.Remove(filename)
+	os.Remove("resources")
 }

--- a/pkg/environment/templateServiceaccount_test.go
+++ b/pkg/environment/templateServiceaccount_test.go
@@ -11,7 +11,6 @@ import (
 // called 00-namespace.yaml
 func TestCreateServiceAccountFiles(t *testing.T) {
 	svc := ServiceAccount{
-		Name:      "testName",
 		Namespace: "foobar",
 	}
 
@@ -22,12 +21,12 @@ func TestCreateServiceAccountFiles(t *testing.T) {
 	if err != nil {
 		t.Error("Error copying file:", err)
 	}
-	err = svc.createSvcAccFile(svc.Name)
+	err = svc.createSvcAccFile()
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
 
-	fileContainsString(t, svcAccFileName, svc.Name)
+	fileContainsString(t, svcAccFileName, "cloud-platform-user")
 	fileContainsString(t, svcAccFileName, svc.Namespace)
 
 	os.Remove(svcAccFileName)

--- a/pkg/environment/templateServiceacount.go
+++ b/pkg/environment/templateServiceacount.go
@@ -17,7 +17,7 @@ type ServiceAccount struct {
 // CreateTemplateServiceAccount sets and creates a template file containing all
 // the necessary values to create a serviceaccount resource in Kubernetes. It
 // will only execute in a directory with a namespace resource i.e. 00-namespace.yaml.
-func CreateTemplateServiceAccount(name string) error {
+func CreateTemplateServiceAccount() error {
 	re := RepoEnvironment{}
 	err := re.mustBeInANamespaceFolder()
 	if err != nil {
@@ -25,7 +25,7 @@ func CreateTemplateServiceAccount(name string) error {
 	}
 	v := ServiceAccount{}
 
-	err = v.createSvcAccFile(name)
+	err = v.createSvcAccFile()
 	if err != nil {
 		return err
 	}
@@ -38,33 +38,18 @@ func CreateTemplateServiceAccount(name string) error {
 
 // createSvcAccountFile uses the values of a ServiceAccount object to interpolate the serviceaccount
 // template, it then creates a file in the current working directory.
-func (v *ServiceAccount) createSvcAccFile(name string) error {
-	err := v.setSvcAccValues(name)
-	if err != nil {
-		return err
-	}
-
+func (v *ServiceAccount) createSvcAccFile() error {
 	tmpl, err := setSvcAccTemplate()
 	if err != nil {
 		return err
 	}
 
+	v.Name = "cloud-platform-user"
+
 	err = v.writeSvcAccFile(tmpl)
 	if err != nil {
 		return err
 	}
-
-	return nil
-}
-
-// setSvcValues takes a ServiceAccount object and populates it with the namespace
-// value (from the 00-namespace.yaml file) and the name argument from cobra.
-func (v *ServiceAccount) setSvcAccValues(name string) error {
-	ns := Namespace{}
-	ns.ReadYaml()
-
-	v.Name = name
-	v.Namespace = ns.Namespace
 
 	return nil
 }


### PR DESCRIPTION
This alters the cli tool to create a serviceaccount as `resources/serviceaccount.tf`, by copying [this file](https://raw.githubusercontent.com/ministryofjustice/cloud-platform-terraform-serviceaccount/main/template/serviceaccount.tmpl), instead of using the previous YAML template.

> Please create release 1.7.2 after merging this PR
