### PR TITLE
Create gov.uk prototypes on the cloud platform

### DIFF
--- a/pkg/commands/environment.go
+++ b/pkg/commands/environment.go
@@ -18,6 +18,8 @@ func addEnvironmentCmd(topLevel *cobra.Command) {
 	environmentRdsCmd.AddCommand(environmentRdsCreateCmd)
 	environmentS3Cmd.AddCommand(environmentS3CreateCmd)
 	environmentSvcCmd.AddCommand(environmentSvcCreateCmd)
+	environmentCmd.AddCommand(environmentPrototypeCmd)
+	environmentPrototypeCmd.AddCommand(environmentPrototypeCreateCmd)
 }
 
 var environmentCmd = &cobra.Command{
@@ -102,6 +104,46 @@ var environmentSvcCreateCmd = &cobra.Command{
 	PreRun: upgradeIfNotLatest,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := environment.CreateTemplateServiceAccount(); err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var environmentPrototypeCmd = &cobra.Command{
+	Use:   "prototype",
+	Short: `Create a gov.uk prototype kit site on the cloud platform`,
+	Example: heredoc.Doc(`
+	$ cloud-platform environment prototype
+	`),
+	PreRun: upgradeIfNotLatest,
+}
+
+var environmentPrototypeCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: `Create a gov.uk prototype kit site on the cloud platform`,
+	Long: `
+Create a namespace folder and a github repository to host a Gov.UK
+Prototype Kit website on the Cloud Platform.
+
+The github repository will be:
+
+  https://github.com/ministryofjustice/[namespace name]
+
+The prototype site will be hosted at:
+
+  https://[namespace name].apps.live-1.cloud-platform.service.justice.gov.uk
+
+A continuous deployment workflow will be created in the github repository such
+that any changes to the 'main' branch are deployed to the cloud platform.
+	`,
+	Example: heredoc.Doc(`
+	$ cloud-platform environment prototype create
+	`),
+	PreRun: upgradeIfNotLatest,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := environment.CreateTemplatePrototype(); err != nil {
 			return err
 		}
 

--- a/pkg/commands/environment.go
+++ b/pkg/commands/environment.go
@@ -97,7 +97,7 @@ var environmentSvcCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: `Creates a serviceaccount in your chosen namespace`,
 	Example: heredoc.Doc(`
-	$ cloud-platform environment serviceaccount create -n circleci
+	$ cloud-platform environment serviceaccount create
 	`),
 	PreRun: upgradeIfNotLatest,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -13,7 +13,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.7.2"
+var Version = "1.8.0"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"

--- a/pkg/environment/common.go
+++ b/pkg/environment/common.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"text/template"
 )
 
 const cloudPlatformEnvRepo = "cloud-platform-environments"
@@ -71,5 +72,25 @@ func copyUrlToFile(url string, targetFilename string) error {
 	f.WriteString(str)
 	f.Close()
 
+	return nil
+}
+
+func createFilesFromTemplates(templates []*templateFromUrl, values Namespace) error {
+	for _, i := range templates {
+		t, err := template.New("").Parse(i.content)
+		if err != nil {
+			return err
+		}
+
+		f, err := os.Create(i.outputPath)
+		if err != nil {
+			return err
+		}
+
+		err = t.Execute(f, values)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/pkg/environment/common.go
+++ b/pkg/environment/common.go
@@ -57,3 +57,19 @@ func directoryExists(path string) bool {
 		return false
 	}
 }
+
+func copyUrlToFile(url string, targetFilename string) error {
+	str, err := downloadTemplate(url)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Create(targetFilename)
+	if err != nil {
+		return err
+	}
+	f.WriteString(str)
+	f.Close()
+
+	return nil
+}

--- a/pkg/environment/inListValidator.go
+++ b/pkg/environment/inListValidator.go
@@ -15,7 +15,7 @@ func (v *inListValidator) isValid(s string) bool {
 			return true
 		}
 	}
-	// TODO: output the list
+
 	fmt.Printf("Value must be in the list: %s\n", strings.Join(v.list, ", "))
 	return false
 }

--- a/pkg/environment/namespace.go
+++ b/pkg/environment/namespace.go
@@ -24,11 +24,11 @@ type Namespace struct {
 	SourceCode            string
 }
 
+// This is a public function so that we can use it in our tests
 func (ns *Namespace) ReadYaml() error {
 	return ns.readYamlFile(NamespaceYamlFile)
 }
 
-// This is a public function so that we can use it in our tests
 func (ns *Namespace) readYamlFile(filename string) error {
 	contents, err := ioutil.ReadFile(filename)
 	if err != nil {

--- a/pkg/environment/prototype.go
+++ b/pkg/environment/prototype.go
@@ -1,0 +1,10 @@
+package environment
+
+// Prototype represents a gov.uk prototype kit hosted on the cloud platform.
+// Under the hood, this is a namespace and a github repository of the same
+// name, connected via a github actions continuous deployment workflow and
+// github actions secrets containing the namespace details, ecr &
+// serviceaccount credentials.
+type Prototype struct {
+	Namespace Namespace
+}

--- a/pkg/environment/prototype.go
+++ b/pkg/environment/prototype.go
@@ -10,5 +10,3 @@ type Prototype struct {
 	BasicAuthUsername string
 	BasicAuthPassword string
 }
-
-}

--- a/pkg/environment/prototype.go
+++ b/pkg/environment/prototype.go
@@ -6,5 +6,9 @@ package environment
 // github actions secrets containing the namespace details, ecr &
 // serviceaccount credentials.
 type Prototype struct {
-	Namespace Namespace
+	Namespace         Namespace
+	BasicAuthUsername string
+	BasicAuthPassword string
+}
+
 }

--- a/pkg/environment/templateEnvironment.go
+++ b/pkg/environment/templateEnvironment.go
@@ -3,7 +3,6 @@ package environment
 import (
 	"fmt"
 	"os"
-	"text/template"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/gookit/color"
@@ -221,22 +220,11 @@ func createNamespaceFiles(nsValues *Namespace) error {
 		return err
 	}
 
-	for _, i := range templates {
-		t, err := template.New("").Parse(i.content)
-		if err != nil {
-			return err
-		}
-
-		f, err := os.Create(i.outputPath)
-		if err != nil {
-			return err
-		}
-
-		err = t.Execute(f, nsValues)
-		if err != nil {
-			return err
-		}
+	err = createFilesFromTemplates(templates, *nsValues)
+	if err != nil {
+		return err
 	}
+
 	return nil
 }
 

--- a/pkg/environment/templatePrototype.go
+++ b/pkg/environment/templatePrototype.go
@@ -40,6 +40,10 @@ func createPrototypeFiles(p *Prototype) error {
 
 	p.appendBasicAuthVariables()
 
+	nsdir := namespaceBaseFolder + "/" + p.Namespace.Namespace
+	createEcrTfFileInNamespaceDirectory(nsdir)
+	createSvcAccTfFileInNamespaceDirectory(nsdir)
+
 	return nil
 }
 

--- a/pkg/environment/templatePrototype.go
+++ b/pkg/environment/templatePrototype.go
@@ -11,12 +11,11 @@ import (
 const prototypeTemplateUrl = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/moj-prototype/namespace-resources-cli-template/resources/prototype"
 
 func CreateTemplatePrototype() error {
-	// TODO - uncomment this block
-	// re := RepoEnvironment{}
-	// err := re.mustBeInCloudPlatformEnvironments()
-	// if err != nil {
-	// 	return err
-	// }
+	re := RepoEnvironment{}
+	err := re.mustBeInCloudPlatformEnvironments()
+	if err != nil {
+		return err
+	}
 
 	proto, err := promptUserForPrototypeValues()
 	if err != nil {

--- a/pkg/environment/templatePrototype.go
+++ b/pkg/environment/templatePrototype.go
@@ -1,0 +1,8 @@
+package environment
+
+import "fmt"
+
+func CreateTemplatePrototype() error {
+	fmt.Println("CreateTemplatePrototype...")
+	return nil
+}

--- a/pkg/environment/templatePrototype.go
+++ b/pkg/environment/templatePrototype.go
@@ -28,8 +28,36 @@ func CreateTemplatePrototype() error {
 		return err
 	}
 
-	fmt.Println("CreateTemplatePrototype...")
-	fmt.Println("Name: " + proto.Namespace.Namespace)
+	s := proto.Namespace.Namespace
+
+	fmt.Printf(`
+Please run:
+
+    git add %s
+
+...and raise a pull request.
+
+Shortly after your pull request is merged, you should have access to a new
+github repository:
+
+	https://github.com/ministryofjustice/%s
+
+This is a normal gov.uk prototype kit repository, which you can checkout and
+work on in the usual way.
+
+Changes merged and pushed to the 'main' branch of this repository will be
+automatically deployed to your gov.uk prototype kit website. This usually takes
+around 5 minutes.
+
+Your prototype kit website will be served at the URL:
+
+    https://%s.apps.live-1.cloud-platform.service.justice.gov.uk/
+
+If you have any questions or feedback, please post them in #ask-cloud-platform
+on slack.
+
+	`, namespaceBaseFolder+"/"+s, s, s)
+
 	return nil
 }
 

--- a/pkg/environment/templatePrototype.go
+++ b/pkg/environment/templatePrototype.go
@@ -22,7 +22,7 @@ func CreateTemplatePrototype() error {
 		return (err)
 	}
 
-	err = createPrototypeFiles(&proto)
+	err = createPrototypeFiles(proto)
 	if err != nil {
 		return err
 	}

--- a/pkg/environment/templatePrototype.go
+++ b/pkg/environment/templatePrototype.go
@@ -7,8 +7,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 )
 
-// TODO: change to "main" branch
-const prototypeTemplateUrl = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/moj-prototype/namespace-resources-cli-template/resources/prototype"
+const prototypeTemplateUrl = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/main/namespace-resources-cli-template/resources/prototype"
 
 func CreateTemplatePrototype() error {
 	re := RepoEnvironment{}

--- a/pkg/environment/templatePrototype.go
+++ b/pkg/environment/templatePrototype.go
@@ -32,6 +32,7 @@ func CreateTemplatePrototype() error {
 //------------------------------------------------------------------------------
 
 func promptUserForPrototypeValues() (*Prototype, error) {
+	proto := Prototype{}
 	values := Namespace{}
 
 	q := userQuestion{
@@ -122,7 +123,35 @@ func promptUserForPrototypeValues() (*Prototype, error) {
 	values.Application = "Gov.UK Prototype Kit"
 	values.SourceCode = "https://github.com/ministryofjustice/" + values.Namespace
 
-	proto := Prototype{Namespace: values}
+	fmt.Println(`
+Prototype kit websites must be protected by HTTP basic
+authentication, so that citizens don't mistake them for
+real government services.
+You need to choose a username and password for your site.
+
+NB: The username and password you choose will be stored in
+plaintext in a public github repository, so do not choose any
+sensitive values here.`)
+
+	q = userQuestion{
+		description: heredoc.Doc(`Please choose a username for your site:
+		`),
+		prompt:    "Username",
+		validator: new(notEmptyValidator),
+	}
+	q.getAnswer()
+	proto.BasicAuthUsername = q.value
+
+	q = userQuestion{
+		description: heredoc.Doc(`Please choose a password for your site:
+		`),
+		prompt:    "Password",
+		validator: new(notEmptyValidator),
+	}
+	q.getAnswer()
+	proto.BasicAuthPassword = q.value
+
+	proto.Namespace = values
 
 	return &proto, nil
 }

--- a/pkg/environment/templatePrototype.go
+++ b/pkg/environment/templatePrototype.go
@@ -7,6 +7,14 @@ import (
 	"github.com/MakeNowJust/heredoc"
 )
 
+// TODO: change to "main" branch
+const prototypeEcrTemplate = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/moj-prototype/namespace-resources-cli-template/resources/prototype/ecr.tf"
+const prototypeEcrFile = "resources/ecr.tf"
+
+// TODO: change to "main" branch
+const prototypeServiceAccountTemplate = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/moj-prototype/namespace-resources-cli-template/resources/prototype/serviceaccount.tf"
+const prototypeServiceAccountFile = "resources/serviceaccount.tf"
+
 func CreateTemplatePrototype() error {
 	// TODO - uncomment this block
 	// re := RepoEnvironment{}
@@ -31,21 +39,6 @@ func CreateTemplatePrototype() error {
 }
 
 //------------------------------------------------------------------------------
-
-func createPrototypeFiles(p *Prototype) error {
-	err := createNamespaceFiles(&p.Namespace)
-	if err != nil {
-		return err
-	}
-
-	p.appendBasicAuthVariables()
-
-	nsdir := namespaceBaseFolder + "/" + p.Namespace.Namespace
-	createEcrTfFileInNamespaceDirectory(nsdir)
-	createSvcAccTfFileInNamespaceDirectory(nsdir)
-
-	return nil
-}
 
 func promptUserForPrototypeValues() (*Prototype, error) {
 	proto := Prototype{}
@@ -170,6 +163,22 @@ sensitive values here.`)
 	proto.Namespace = values
 
 	return &proto, nil
+}
+
+func createPrototypeFiles(p *Prototype) error {
+	err := createNamespaceFiles(&p.Namespace)
+	if err != nil {
+		return err
+	}
+
+	p.appendBasicAuthVariables()
+
+	nsdir := namespaceBaseFolder + "/" + p.Namespace.Namespace
+
+	copyUrlToFile(prototypeEcrTemplate, nsdir+"/"+prototypeEcrFile)
+	copyUrlToFile(prototypeServiceAccountTemplate, nsdir+"/"+prototypeServiceAccountFile)
+
+	return nil
 }
 
 // Append the extra terraform variables required by a prototype site

--- a/pkg/environment/templatePrototype.go
+++ b/pkg/environment/templatePrototype.go
@@ -14,24 +14,24 @@ func CreateTemplatePrototype() error {
 	// 	return err
 	// }
 
-	nsValues, err := promptUserForPrototypeValues()
+	proto, err := promptUserForPrototypeValues()
 	if err != nil {
 		return (err)
 	}
 
-	err = createNamespaceFiles(nsValues)
+	err = createNamespaceFiles(&proto.Namespace)
 	if err != nil {
 		return err
 	}
 
 	fmt.Println("CreateTemplatePrototype...")
-	fmt.Println("Name: " + nsValues.Namespace)
+	fmt.Println("Name: " + proto.Namespace.Namespace)
 	return nil
 }
 
 //------------------------------------------------------------------------------
 
-func promptUserForPrototypeValues() (*Namespace, error) {
+func promptUserForPrototypeValues() (*Prototype, error) {
 	values := Namespace{}
 
 	q := userQuestion{
@@ -122,5 +122,7 @@ func promptUserForPrototypeValues() (*Namespace, error) {
 	values.Application = "Gov.UK Prototype Kit"
 	values.SourceCode = "https://github.com/ministryofjustice/" + values.Namespace
 
-	return &values, nil
+	proto := Prototype{Namespace: values}
+
+	return &proto, nil
 }

--- a/pkg/environment/templatePrototype.go
+++ b/pkg/environment/templatePrototype.go
@@ -1,8 +1,126 @@
 package environment
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+)
 
 func CreateTemplatePrototype() error {
+	// TODO - uncomment this block
+	// re := RepoEnvironment{}
+	// err := re.mustBeInCloudPlatformEnvironments()
+	// if err != nil {
+	// 	return err
+	// }
+
+	nsValues, err := promptUserForPrototypeValues()
+	if err != nil {
+		return (err)
+	}
+
+	err = createNamespaceFiles(nsValues)
+	if err != nil {
+		return err
+	}
+
 	fmt.Println("CreateTemplatePrototype...")
+	fmt.Println("Name: " + nsValues.Namespace)
 	return nil
+}
+
+//------------------------------------------------------------------------------
+
+func promptUserForPrototypeValues() (*Namespace, error) {
+	values := Namespace{}
+
+	q := userQuestion{
+		description: heredoc.Doc(`Please choose a hostname for your prototype.
+			 This must consist only of lower-case letters, digits and
+			 dashes.
+
+			 This will be;
+			 * the name of the prototype's namespace on the Cloud Platform
+			 * the name of the prototype's github repository
+			 * part of the prototype's URL on the web
+
+			 e.g. if you choose "my-awesome-prototype", then the eventual
+			 URL of the prototype will be:
+
+			 https://my-awesome-prototype.apps.live-1.cloud-platform.service.justice.gov.uk/
+
+			 `),
+		prompt:    "Name",
+		validator: new(namespaceNameValidator),
+	}
+	q.getAnswer()
+	// TODO: check that there isn't already a namespace or github repository with this name
+	values.Namespace = q.value
+
+	q = userQuestion{
+		description: heredoc.Doc(`What is the name of your GitHub team?
+			The users in this GitHub team will be assigned administrator permission
+			for this Cloud Platform environment, and the github repository.
+
+			Please enter the name in lower-case, with hyphens instead of spaces
+			i.e. "Check My Diary" -> "check-my-diary"
+
+			(this must be an exact match, or you will not have access to your
+			namespace or github repository)",
+			 `),
+		prompt:    "GitHub Team",
+		validator: new(githubTeamNameValidator),
+	}
+	q.getAnswer()
+	values.GithubTeam = q.value
+
+	q = userQuestion{
+		description: heredoc.Doc(`Which part of the MoJ is responsible for this service?
+			 `),
+		prompt:    "Business Unit",
+		validator: new(businessUnitValidator),
+	}
+	q.getAnswer()
+	values.BusinessUnit = q.value
+
+	q = userQuestion{
+		description: heredoc.Doc(`What is the best slack channel (without the '#')
+			to use if we need to contact your team?
+			(If you don't have a team slack channel, please create one)",
+			 `),
+		prompt:    "Team Slack Channel",
+		validator: new(slackChannelValidator),
+	}
+	q.getAnswer()
+	values.SlackChannel = q.value
+
+	q = userQuestion{
+		description: heredoc.Doc(`What is the email address for the team
+			which owns the application?
+			(this should not be a named individual's email address)
+			 `),
+		prompt:    "Team Email",
+		validator: new(teamEmailValidator),
+	}
+	q.getAnswer()
+
+	q = userQuestion{
+		description: heredoc.Doc(`Which team in your organisation is responsible
+			for this application? (e.g. Sentence Planning)
+			 `),
+		prompt:    "Team",
+		validator: new(notEmptyValidator),
+	}
+	q.getAnswer()
+	values.Owner = q.value
+
+	values.InfrastructureSupport = q.value
+
+	// We can infer all the following, for a prototype
+	values.Environment = "development"
+	values.IsProduction = "false"
+	values.Application = "Gov.UK Prototype Kit"
+	values.SourceCode = "https://github.com/ministryofjustice/" + values.Namespace
+
+	return &values, nil
 }

--- a/pkg/environment/templatePrototype.go
+++ b/pkg/environment/templatePrototype.go
@@ -3,7 +3,6 @@ package environment
 import (
 	"fmt"
 	"os"
-	"text/template"
 
 	"github.com/MakeNowJust/heredoc"
 )
@@ -186,23 +185,11 @@ func createPrototypeFiles(p *Prototype) error {
 		return err
 	}
 
-	// TODO: refactor this - it's used in templateEnvironment.go as well
-	for _, i := range templates {
-		t, err := template.New("").Parse(i.content)
-		if err != nil {
-			return err
-		}
-
-		f, err := os.Create(i.outputPath)
-		if err != nil {
-			return err
-		}
-
-		err = t.Execute(f, p.Namespace)
-		if err != nil {
-			return err
-		}
+	err = createFilesFromTemplates(templates, p.Namespace)
+	if err != nil {
+		return err
 	}
+
 	return nil
 }
 

--- a/pkg/environment/templatePrototype_test.go
+++ b/pkg/environment/templatePrototype_test.go
@@ -30,6 +30,7 @@ func TestCreatePrototype(t *testing.T) {
 	namespaceFile := dir + "00-namespace.yaml"
 	rbacFile := dir + "01-rbac.yaml"
 	variablesTfFile := dir + "resources/variables.tf"
+	githubRepoTfFile := dir + "resources/github-repo.tf"
 
 	filenames := []string{
 		namespaceFile,
@@ -41,7 +42,9 @@ func TestCreatePrototype(t *testing.T) {
 		variablesTfFile,
 		dir + "resources/ecr.tf",
 		dir + "resources/serviceaccount.tf",
+		dir + "resources/basic-auth.tf",
 		dir + "resources/versions.tf",
+		githubRepoTfFile,
 	}
 
 	for _, f := range filenames {

--- a/pkg/environment/templatePrototype_test.go
+++ b/pkg/environment/templatePrototype_test.go
@@ -75,3 +75,10 @@ func TestCreatePrototype(t *testing.T) {
 
 	cleanUpNamespacesFolder("foobar")
 }
+
+func TestOutsideEnvironmentsWorkingCopy(t *testing.T) {
+	err := CreateTemplatePrototype()
+	if err.Error() != "This command may only be run from within a working copy of the cloud-platform-environments repository\n" {
+		t.Errorf("Unexpected error: %s", err)
+	}
+}

--- a/pkg/environment/templatePrototype_test.go
+++ b/pkg/environment/templatePrototype_test.go
@@ -31,6 +31,7 @@ func TestCreatePrototype(t *testing.T) {
 	rbacFile := dir + "01-rbac.yaml"
 	variablesTfFile := dir + "resources/variables.tf"
 	githubRepoTfFile := dir + "resources/github-repo.tf"
+	ecrTfFile := dir + "resources/ecr.tf"
 
 	filenames := []string{
 		namespaceFile,
@@ -40,7 +41,7 @@ func TestCreatePrototype(t *testing.T) {
 		dir + "04-networkpolicy.yaml",
 		dir + "resources/main.tf",
 		variablesTfFile,
-		dir + "resources/ecr.tf",
+		ecrTfFile,
 		dir + "resources/serviceaccount.tf",
 		dir + "resources/basic-auth.tf",
 		dir + "resources/versions.tf",
@@ -54,16 +55,18 @@ func TestCreatePrototype(t *testing.T) {
 	}
 
 	stringsInFiles := map[string]string{
-		namespaceFile:   "name: foobar",
-		namespaceFile:   "cloud-platform.justice.gov.uk/business-unit: \"My Biz Unit\"",
-		namespaceFile:   "cloud-platform.justice.gov.uk/environment-name: \"envname\"",
-		namespaceFile:   "cloud-platform.justice.gov.uk/application: \"My App\"",
-		namespaceFile:   "cloud-platform.justice.gov.uk/owner: \"Some Team: some-team@digital.justice.gov.uk\"",
-		namespaceFile:   "cloud-platform.justice.gov.uk/source-code: \"https://github.com/ministryofjustice/somerepo\"",
-		namespaceFile:   "cloud-platform.justice.gov.uk/is-production: \"false\"",
-		rbacFile:        "name: \"github:my-github-team\"",
-		variablesTfFile: "my-team-slack_channel",
-		variablesTfFile: "my-github-team",
+		namespaceFile:    "name: foobar",
+		namespaceFile:    "cloud-platform.justice.gov.uk/business-unit: \"My Biz Unit\"",
+		namespaceFile:    "cloud-platform.justice.gov.uk/environment-name: \"envname\"",
+		namespaceFile:    "cloud-platform.justice.gov.uk/application: \"My App\"",
+		namespaceFile:    "cloud-platform.justice.gov.uk/owner: \"Some Team: some-team@digital.justice.gov.uk\"",
+		namespaceFile:    "cloud-platform.justice.gov.uk/source-code: \"https://github.com/ministryofjustice/somerepo\"",
+		namespaceFile:    "cloud-platform.justice.gov.uk/is-production: \"false\"",
+		rbacFile:         "name: \"github:my-github-team\"",
+		variablesTfFile:  "my-team-slack_channel",
+		variablesTfFile:  "my-github-team",
+		githubRepoTfFile: "slug = \"my-github-team\"",
+		ecrTfFile:        "github_repositories = [var.namespace]",
 	}
 
 	for filename, searchString := range stringsInFiles {

--- a/pkg/environment/templatePrototype_test.go
+++ b/pkg/environment/templatePrototype_test.go
@@ -1,0 +1,71 @@
+package environment
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCreatePrototype(t *testing.T) {
+	ns := Namespace{
+		Namespace:             "foobar",
+		BusinessUnit:          "My Biz Unit",
+		Environment:           "envname",
+		Application:           "My App",
+		Owner:                 "Some Team",
+		InfrastructureSupport: "some-team@digital.justice.gov.uk",
+		SourceCode:            "https://github.com/ministryofjustice/somerepo",
+		GithubTeam:            "my-github-team",
+		SlackChannel:          "my-team-slack_channel",
+		IsProduction:          "false",
+	}
+	proto := Prototype{
+		Namespace:         ns,
+		BasicAuthUsername: "myusername",
+		BasicAuthPassword: "mypassword",
+	}
+
+	createPrototypeFiles(&proto)
+
+	dir := namespaceBaseFolder + "/foobar/"
+	namespaceFile := dir + "00-namespace.yaml"
+	rbacFile := dir + "01-rbac.yaml"
+	variablesTfFile := dir + "resources/variables.tf"
+
+	filenames := []string{
+		namespaceFile,
+		rbacFile,
+		dir + "02-limitrange.yaml",
+		dir + "03-resourcequota.yaml",
+		dir + "04-networkpolicy.yaml",
+		dir + "resources/main.tf",
+		variablesTfFile,
+		dir + "resources/ecr.tf",
+		dir + "resources/serviceaccount.tf",
+		dir + "resources/versions.tf",
+	}
+
+	for _, f := range filenames {
+		if _, err := os.Stat(f); os.IsNotExist(err) {
+			t.Errorf("Expected file %s to be created", f)
+		}
+	}
+
+	stringsInFiles := map[string]string{
+		namespaceFile:   "name: foobar",
+		namespaceFile:   "cloud-platform.justice.gov.uk/business-unit: \"My Biz Unit\"",
+		namespaceFile:   "cloud-platform.justice.gov.uk/environment-name: \"envname\"",
+		namespaceFile:   "cloud-platform.justice.gov.uk/application: \"My App\"",
+		namespaceFile:   "cloud-platform.justice.gov.uk/owner: \"Some Team: some-team@digital.justice.gov.uk\"",
+		namespaceFile:   "cloud-platform.justice.gov.uk/source-code: \"https://github.com/ministryofjustice/somerepo\"",
+		namespaceFile:   "cloud-platform.justice.gov.uk/is-production: \"false\"",
+		rbacFile:        "name: \"github:my-github-team\"",
+		variablesTfFile: "my-team-slack_channel",
+		variablesTfFile: "my-github-team",
+	}
+
+	for filename, searchString := range stringsInFiles {
+		fileContainsString(t, filename, searchString)
+	}
+
+	cleanUpNamespacesFolder("foobar")
+}

--- a/pkg/environment/templateServiceacount.go
+++ b/pkg/environment/templateServiceacount.go
@@ -2,7 +2,6 @@ package environment
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/gookit/color"
 )
@@ -37,17 +36,5 @@ func CreateTemplateServiceAccount() error {
 func createSvcAccTfFile() error {
 	// The serviceaccount "template" is actually an example file that we can just save
 	// as is into the user's resources/ directory as `serviceaccount.tf`
-	svcAccTemplate, err := downloadTemplate(svcAccTemplateFile)
-	if err != nil {
-		return err
-	}
-
-	f, err := os.Create(svcAccTfFile)
-	if err != nil {
-		return err
-	}
-	f.WriteString(svcAccTemplate)
-	f.Close()
-
-	return nil
+	return copyUrlToFile(svcAccTemplateFile, svcAccTfFile)
 }

--- a/pkg/environment/templatesEcr.go
+++ b/pkg/environment/templatesEcr.go
@@ -2,7 +2,6 @@ package environment
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/gookit/color"
 	"github.com/spf13/cobra"
@@ -34,17 +33,5 @@ func CreateTemplateEcr(cmd *cobra.Command, args []string) error {
 func createEcrTfFile() error {
 	// The ecr "template" is actually an example file that we can just save
 	// "as is" into the user's resources/ directory as `ecr.tf`
-	ecrTemplate, err := downloadTemplate(ecrTemplateFile)
-	if err != nil {
-		return err
-	}
-
-	f, err := os.Create(ecrTfFile)
-	if err != nil {
-		return err
-	}
-	f.WriteString(ecrTemplate)
-	f.Close()
-
-	return nil
+	return copyUrlToFile(ecrTemplateFile, ecrTfFile)
 }

--- a/pkg/environment/templatesS3.go
+++ b/pkg/environment/templatesS3.go
@@ -2,7 +2,6 @@ package environment
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/gookit/color"
 	"github.com/spf13/cobra"
@@ -35,17 +34,5 @@ func CreateTemplateS3(cmd *cobra.Command, args []string) error {
 func createS3TfFile() error {
 	// The s3 "template" is actually an example file that we can just save
 	// "as is" into the user's resources/ directory as `s3.tf`
-	s3Template, err := downloadTemplate(s3TemplateFile)
-	if err != nil {
-		return err
-	}
-
-	f, err := os.Create(s3TfFile)
-	if err != nil {
-		return err
-	}
-	f.WriteString(s3Template)
-	f.Close()
-
-	return nil
+	return copyUrlToFile(s3TemplateFile, s3TfFile)
 }


### PR DESCRIPTION
This adds a new feature to the CLI:

```
cloud-platform environment prototype create
```

This creates a namespace and a linked github repository with the gov.uk prototype kit, which automatically deploys any changes to the namespace via github actions.

- Remove `-n circleci` from serviceaccount help text
- Add a stub command for creating a prototype site
- Move a misplaced comment
- WiP: Prompt the user for prototype details
- Add Prototype struct, encapsulating the Namespace
- Ask user for basic auth credentials
- Add basic auth values to resources/variables.tf
- Add ECR & serviceaccount to prototype namespace
- Add tests for protoype
- Add copyUrlToFile function
- Create ecr.tf and serviceaccount.tf for prototype
- Create resources/github-repo.tf for prototype
- Add more tests for prototype
- Refactor using copyUrlToFile function
- Refactor: extract `createFileFromTemplates` func
- Output helpful message after prototype creation
- Ensure prototype create only runs in env. repo
- Bugfix: 'proto' not '&proto'
- Remove outdated comment
- Change URL of prototype templates
- Bump version number to 1.8.0
