### PR TITLE
Add review-after annotation to scratch namespaces

### DIFF
--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -13,7 +13,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.8.1"
+var Version = "1.8.2"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"

--- a/pkg/environment/namespace.go
+++ b/pkg/environment/namespace.go
@@ -22,6 +22,7 @@ type Namespace struct {
 	OwnerEmail            string
 	SlackChannel          string
 	SourceCode            string
+	ReviewAfter           string
 }
 
 // This is a public function so that we can use it in our tests
@@ -54,6 +55,7 @@ func (ns *Namespace) parseYaml(yamlData []byte) error {
 				Application  string `yaml:"cloud-platform.justice.gov.uk/application"`
 				Owner        string `yaml:"cloud-platform.justice.gov.uk/owner"`
 				SourceCode   string `yaml:"cloud-platform.justice.gov.uk/source-code"`
+				ReviewAfter  string `yaml:"cloud-platform.justice.gov.uk/review-after"`
 			} `yaml:"annotations"`
 		} `yaml:"metadata"`
 	}
@@ -74,6 +76,7 @@ func (ns *Namespace) parseYaml(yamlData []byte) error {
 	ns.Owner = t.Metadata.Annotations.Owner
 	ns.OwnerEmail = strings.Split(t.Metadata.Annotations.Owner, ": ")[1]
 	ns.SourceCode = t.Metadata.Annotations.SourceCode
+	ns.ReviewAfter = t.Metadata.Annotations.ReviewAfter
 
 	return nil
 }

--- a/pkg/environment/templateEnvironment.go
+++ b/pkg/environment/templateEnvironment.go
@@ -73,13 +73,17 @@ func promptUserForNamespaceValues() (*Namespace, error) {
 		q = userQuestion{
 			description: heredoc.Doc(`
 			Is this a production namespace?
-			Please enter "true" or "false"
+			Please enter "yes" or "no"
 			 `),
 			prompt:    "Production?",
-			validator: new(trueFalseValidator),
+			validator: new(yesNoValidator),
 		}
 		q.getAnswer()
-		values.IsProduction = q.value
+		if q.value == "yes" {
+			values.IsProduction = "true"
+		} else {
+			values.IsProduction = "false"
+		}
 	}
 
 	q = userQuestion{

--- a/pkg/environment/templateEnvironment.go
+++ b/pkg/environment/templateEnvironment.go
@@ -3,6 +3,7 @@ package environment
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/gookit/color"
@@ -67,8 +68,21 @@ func promptUserForNamespaceValues() (*Namespace, error) {
 	q.getAnswer()
 	values.Environment = q.value
 
-	if q.value == "development" {
+	if q.value == "development" || q.value == "dev" {
 		values.IsProduction = "false"
+
+		q = userQuestion{
+			description: heredoc.Doc(`
+			Is this a sandbox/scratch namespace (e.g. for experimentation, or working through a tutorial)?
+			Please enter "yes" or "no"
+			 `),
+			prompt:    "Sandbox?",
+			validator: new(yesNoValidator),
+		}
+		q.getAnswer()
+		if q.value == "yes" {
+			values.ReviewAfter = reviewAfter()
+		}
 	} else {
 		q = userQuestion{
 			description: heredoc.Doc(`
@@ -268,4 +282,8 @@ func createDirHash(nsValues *Namespace) error {
 	}
 
 	return nil
+}
+
+func reviewAfter() string {
+	return fmt.Sprintf(time.Now().AddDate(0, 3, 0).Format("2006-01-02"))
 }

--- a/pkg/environment/templateEnvironment.go
+++ b/pkg/environment/templateEnvironment.go
@@ -67,16 +67,20 @@ func promptUserForNamespaceValues() (*Namespace, error) {
 	q.getAnswer()
 	values.Environment = q.value
 
-	q = userQuestion{
-		description: heredoc.Doc(`
+	if q.value == "development" {
+		values.IsProduction = "false"
+	} else {
+		q = userQuestion{
+			description: heredoc.Doc(`
 			Is this a production namespace?
 			Please enter "true" or "false"
 			 `),
-		prompt:    "Prouduction?",
-		validator: new(trueFalseValidator),
+			prompt:    "Production?",
+			validator: new(trueFalseValidator),
+		}
+		q.getAnswer()
+		values.IsProduction = q.value
 	}
-	q.getAnswer()
-	values.IsProduction = q.value
 
 	q = userQuestion{
 		description: heredoc.Doc(`

--- a/pkg/environment/yesNoValidator.go
+++ b/pkg/environment/yesNoValidator.go
@@ -1,0 +1,11 @@
+package environment
+
+type yesNoValidator struct {
+}
+
+func (v *yesNoValidator) isValid(s string) bool {
+	l := inListValidator{
+		list: []string{"yes", "no"},
+	}
+	return l.isValid(s)
+}


### PR DESCRIPTION
This change adds a "review-after" annotation to 00-namespace.yaml if the user says it's a sandbox/scratch namespace.

depends on https://github.com/ministryofjustice/cloud-platform-environments/pull/4272

- If env=="development" don't ask if it's prod
- Allow user to answer yes/no, instead of true/false
- Set "review-after" annotation for sandbox envs.

> I had to revert [this PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/4272) because it breaks the CLI until **this** PR is merged. Once the CLI has been updated, please merge [this replacement PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/4279)