### PR TITLE
Remove team email address question from prototype wizard

### DIFF
--- a/pkg/environment/templatePrototype.go
+++ b/pkg/environment/templatePrototype.go
@@ -126,16 +126,6 @@ func promptUserForPrototypeValues() (*Prototype, error) {
 	values.SlackChannel = q.value
 
 	q = userQuestion{
-		description: heredoc.Doc(`What is the email address for the team
-			which owns the application?
-			(this should not be a named individual's email address)
-			 `),
-		prompt:    "Team Email",
-		validator: new(teamEmailValidator),
-	}
-	q.getAnswer()
-
-	q = userQuestion{
 		description: heredoc.Doc(`Which team in your organisation is responsible
 			for this application? (e.g. Sentence Planning)
 			 `),


### PR DESCRIPTION
The email address is hardcoded as `platforms@digital.justice.gov.uk` so the question doesn't need to be asked.

This confused me during the setup process, because I entered an email address but it didn't go anywhere