### PR TITLE
Remove Team Email question

### DIFF
--- a/pkg/environment/templatePrototype.go
+++ b/pkg/environment/templatePrototype.go
@@ -126,16 +126,6 @@ func promptUserForPrototypeValues() (*Prototype, error) {
 	values.SlackChannel = q.value
 
 	q = userQuestion{
-		description: heredoc.Doc(`What is the email address for the team
-			which owns the application?
-			(this should not be a named individual's email address)
-			 `),
-		prompt:    "Team Email",
-		validator: new(teamEmailValidator),
-	}
-	q.getAnswer()
-
-	q = userQuestion{
 		description: heredoc.Doc(`Which team in your organisation is responsible
 			for this application? (e.g. Sentence Planning)
 			 `),


### PR DESCRIPTION
Remove Team Email question as it is not required as this defaults to platforms@digital.justice.gov.uk for all prototypes