### PR TITLE
Update versions.go

### DIFF
--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -13,7 +13,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.8.5"
+var Version = "1.8.7"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"


### PR DESCRIPTION
This has to be changed to the release tag. Bumping the version and will make a release with this tag. Otherwise this will go on a loop of selfUpgrade.