### PR TITLE
Update version.go

### DIFF
--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -13,7 +13,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.8.7"
+var Version = "1.8.8"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"


### PR DESCRIPTION
In order to trigger a new release without affecting the CLI itself, we need to bump the version