### PR TITLE
Add homebrew tap to Goreleaser

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -30,6 +30,7 @@ jobs:
           workdir: ./cmd/cloud-platform
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
   push_to_registry:
     name: Push image to docker hub

--- a/cmd/cloud-platform/.goreleaser.yml
+++ b/cmd/cloud-platform/.goreleaser.yml
@@ -32,7 +32,7 @@ changelog:
 brews:
   - tap:
       owner: ministryofjustice
-      name: homebrew-cloud-platform-cli
+      name: homebrew-cloud-platform-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     folder: Formula
     homepage: https://user-guide.cloud-platform.service.justice.gov.uk/#cloud-platform-user-guide

--- a/cmd/cloud-platform/.goreleaser.yml
+++ b/cmd/cloud-platform/.goreleaser.yml
@@ -1,3 +1,9 @@
+env:
+  - GO111MODULE=on
+  - GOPROXY=https://gocenter.io
+before:
+  hooks:
+    - go mod download
 builds:
 - env:
     - CGO_ENABLED=0
@@ -23,3 +29,14 @@ changelog:
     - Merge pull request
     - Merge branch
     - go mod tidy
+brews:
+  - tap:
+      owner: ministryofjustice
+      name: homebrew-cloud-platform-cli
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    folder: Formula
+    homepage: https://user-guide.cloud-platform.service.justice.gov.uk/#cloud-platform-user-guide
+    description: Multi-purpose CLI for Ministry of Justice Cloud Platform.
+    license: MIT
+    dependencies:
+    - name: go

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -13,7 +13,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.8.9"
+var Version = "1.9.0"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"


### PR DESCRIPTION
Overview
---
This change enables users of the `cloud-platform-cli` tool to use the popular mac package management tool brew. Users should be able to install the cli via a simple command `brew install ministryofjusice/cloud-platform-tap/cloud-platform-cli`. This change relies on two external entities:
- first that a repository called `homebrew-cloud-platform-tap` exists and contains a directory called `Formula`
- second that a personal access token secret exists (in this repository) called `HOMEBREW_GITHUB_CLI`.