### PR TITLE
Bump GH actions to go 1.16

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,10 +16,10 @@ jobs:
         with:
           fetch-depth: 0 # See: https://goreleaser.com/ci/actions/
 
-      - name: Set up Go 1.13
+      - name: Set up Go 1.16
         uses: actions/setup-go@v2
         with:
-          go-version: 1.13
+          go-version: 1.16
         id: go
 
       - name: Run GoReleaser


### PR DESCRIPTION
I'm hoping this is the cause of the lack of mac arm build in goreleaser.