### PR TITLE
Remove GOPROXY

### DIFF
--- a/cmd/cloud-platform/.goreleaser.yml
+++ b/cmd/cloud-platform/.goreleaser.yml
@@ -1,6 +1,5 @@
 env:
   - GO111MODULE=on
-  - GOPROXY=https://gocenter.io
 before:
   hooks:
     - go mod download

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -13,7 +13,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.9.5"
+var Version = "1.9.6"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"


### PR DESCRIPTION
The last build release failed with error 

```release failed after 0.75s error=hook failed: go mod download: exit status 1; output: go: github.com/MakeNowJust/heredoc@v1.0.0: reading https://gocenter.io/github.com/%21make%21now%21just/heredoc/@v/v1.0.0.mod: 405 Not Allowed```

"gocenter" is deprecated. go module uses https://proxy.golang.org,direct as default. Hence remove setting GOPROXY.