### PR TITLE
Set current-context of cluster, compare the cluster context with workspace 

### DIFF
--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -336,8 +336,10 @@ func (c *Commander) workspaces() ([]string, error) {
 	return ws, nil
 }
 
-// kubectlCurContext return the cluster name of current context set in kubectl.
-func (c *Commander) kubectlCurContext() (string, error) {
+// kubectlContext return the cluster name of current context set in kubectl.
+// PS: It is assumed the context is stored in format <cluster-name>.cloud-platform.service.justice.gov.uk
+// in kubeconfig file from where kubectl fetches the context.
+func (c *Commander) kubectlContext() (string, error) {
 	arg := []string{
 		"config",
 		"current-context",
@@ -404,7 +406,7 @@ func (c *Commander) BulkPlan() error {
 			if err != nil {
 				return err
 			}
-			cluster, err := c.kubectlCurContext()
+			cluster, err := c.kubectlContext()
 			if err != nil {
 				return err
 			}
@@ -436,7 +438,7 @@ func (c *Commander) BulkPlan() error {
 				return err
 			}
 
-			cluster, err := c.kubectlCurContext()
+			cluster, err := c.kubectlContext()
 			if err != nil {
 				return err
 			}
@@ -496,7 +498,7 @@ func (c *Commander) BulkApply() error {
 			if err != nil {
 				return err
 			}
-			cluster, err := c.kubectlCurContext()
+			cluster, err := c.kubectlContext()
 			if err != nil {
 				return err
 			}
@@ -521,7 +523,7 @@ func (c *Commander) BulkApply() error {
 				return err
 			}
 
-			cluster, err := c.kubectlCurContext()
+			cluster, err := c.kubectlContext()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Related to: https://github.com/ministryofjustice/cloud-platform/pull/3049 
- Add kubectl config use-context before doing a terraform plan. This will fix setting wrong context for kubectl commands
- Check kubectl current context and compare with the workspace before doing plan and apply
- Split workspaces with spaces instead of newline - If the current workspace has * and it is the expected one. For example, if the current workspace is manager, the workspace list give `* manager` and when it compares with "manager" it fails.