### PR TITLE
Update terraform binary to 0.14.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ COPY --from=cloud_platform_cli_builder /build/cloud-platform /usr/local/bin/clou
 RUN curl -sLo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl
 
 # Install terraform
-COPY --from=hashicorp/terraform:0.14.7 /bin/terraform /usr/local/bin/terraform
+COPY --from=hashicorp/terraform:0.14.8 /bin/terraform /usr/local/bin/terraform
 
 # Install aws-iam-authenticator (required for EKS)
 RUN curl -sLo /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -13,7 +13,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.9.7"
+var Version = "1.9.8"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"


### PR DESCRIPTION
This is to keep consistency with the tools image so all the cloud platform terraform code uses 0.14.8 version