### PR TITLE
Added ElasticSearch and IAM validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/gookit/color v1.2.5
 	github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 // indirect

--- a/pkg/environment/migrate_test.go
+++ b/pkg/environment/migrate_test.go
@@ -1,0 +1,15 @@
+package environment
+
+import "testing"
+
+func TestGrepFile(t *testing.T) {
+	hasBusinessUnit := grepFile("fixtures/foobar-namespace.yml", []byte("cloud-platform.justice.gov.uk/business-unit"))
+	if hasBusinessUnit == 0 {
+		t.Errorf("Business Unit annotation exist inside fixures file, grepFile() returned %v - expected: 1", hasBusinessUnit)
+	}
+
+	hasRandomAnnotation := grepFile("fixtures/foobar-namespace.yml", []byte("whatever"))
+	if hasRandomAnnotation != 0 {
+		t.Errorf("whatever annotation DOES NOT exist inside fixures file, grepFile() returned %v - expected: 0", hasRandomAnnotation)
+	}
+}


### PR DESCRIPTION
ElasticSearch modules and IAM roles required certain changes which must be done by the user. This PR performs a recursive grep within the namespace to ensure the namespace is not using it. If they are using it, a warn is displayed saying to contact  Cloud-Platform.

## TODO (maybe?): 

Adding HCL parsing, so once identified terraform file with elastic-search module perform the following add/update:
```
irsa_enabled          = "true"
assume_enabled        = "false"

```

 