### PR TITLE
Fix bug: APPLY_PIPELINE_SKIP_THIS_NAMESPACE file in thr wrong folder

### DIFF
--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -13,7 +13,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.12.0"
+var Version = "1.12.1"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"

--- a/pkg/environment/migrate.go
+++ b/pkg/environment/migrate.go
@@ -46,13 +46,6 @@ func Migrate(skipWarning bool) error {
 		}
 	}
 
-	// Required to skip the live-1 pipeline
-	emptyFile, err := os.Create("APPLY_PIPELINE_SKIP_THIS_NAMESPACE")
-	if err != nil {
-		return err
-	}
-	emptyFile.Close()
-
 	src := fmt.Sprintf("../%s", nsName)
 	dst := fmt.Sprintf("../../live.cloud-platform.service.justice.gov.uk/%s", nsName)
 
@@ -60,6 +53,13 @@ func Migrate(skipWarning bool) error {
 	if err != nil {
 		return err
 	}
+
+	// Required to skip the live-1 pipeline
+	emptyFile, err := os.Create("APPLY_PIPELINE_SKIP_THIS_NAMESPACE")
+	if err != nil {
+		return err
+	}
+	emptyFile.Close()
 
 	if err := os.Chdir(dst); err != nil {
 		return err


### PR DESCRIPTION
APPLY_PIPELINE_SKIP_THIS_NAMESPACE file is also added to the live folder but we don't want that. This is happening because of the order we are running the functions.

This PR fixes that problem.