### PR TITLE
build: :bug: Upgrade version of Go when building and releasing

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go 1.16
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
         id: go
 
       - name: Run GoReleaser

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0 # See: https://goreleaser.com/ci/actions/
 
-      - name: Set up Go 1.16
+      - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.17

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Cloud Platform tools (CLI)
-FROM golang:1.16.0-stretch AS cloud_platform_cli_builder
+FROM golang:1.17.0-stretch AS cloud_platform_cli_builder
 
 ENV GO111MODULE=on \
     CGO_ENABLED=0 \

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -13,7 +13,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.14.0"
+var Version = "1.14.1"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"


### PR DESCRIPTION
There is a build error in the `sigs.k8s.io/json/internal/golang/encoding/json` that is fixed by updating to Go 1.17.x