### PR TITLE
build: :green_heart: Move binary build to pre-stage and remove python

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.github
+LICENCE
+Dockerfile
+.build-docker-image
+makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,55 +1,82 @@
 # Build Cloud Platform tools (CLI)
-FROM golang:1.17.0-stretch AS cloud_platform_cli_builder
-
-ENV GO111MODULE=on \
-    CGO_ENABLED=0 \
-    GOOS=linux
-
-WORKDIR /build
-COPY go.mod .
-COPY go.sum .
-RUN go mod download
-COPY . .
-RUN go build -o cloud-platform ./cmd/cloud-platform/main.go 
-RUN pwd && ls
-
-FROM alpine:3.11.0
+FROM golang:1.17-alpine AS cli_builder
 
 ENV \
-  KUBECTL_VERSION=1.20.7 \
-  TERRAFORM_VERSION=0.14.8
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    KUBECTL_VERSION=1.20.7 \
+    TERRAFORM_VERSION=0.14.8
+
+WORKDIR /build
 
 RUN \
   apk add \
     --no-cache \
     --no-progress \
     --update \
-    bash \
-    ca-certificates \
-    coreutils \
     curl \
-    findutils \
-    git-crypt \
-    git \
-    gnupg \
-    grep \
-    openssl \
-    python3
+    unzip
 
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python3 get-pip.py && \
-    pip3 install pygithub boto3 && \
-    pip3 install awscli
-
-COPY --from=cloud_platform_cli_builder /build/cloud-platform /usr/local/bin/cloud-platform
+# Build cli
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY . .
+RUN go build -o cloud-platform ./cmd/cloud-platform/main.go
 
 # Install kubectl
-RUN curl -sLo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+RUN curl -sLo ./kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl
 
 # Install terraform
-RUN curl -sLo terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && unzip terraform.zip && mv terraform /usr/local/bin && rm -f terraform.zip
+RUN curl -sLo terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && unzip terraform.zip
 
-# Ensure everything is executable
-RUN chmod +x /usr/local/bin/*
+RUN chmod +x kubectl terraform
 
-CMD /bin/bash
+# ---
+
+FROM alpine:3.14
+
+ENV AWSCLI_VERSION=2.2.41
+ENV GLIBC_VER=2.31-r0
+
+RUN apk add --update --no-cache \
+  groff \
+  bash \
+  ca-certificates \
+  coreutils \
+  findutils \
+  git-crypt \
+  git \
+  gnupg \
+  grep \
+  openssl
+
+
+# AWS cli installation taken from https://github.com/aws/aws-cli/issues/4685#issuecomment-941927371
+RUN apk add --no-cache --virtual .dependencies binutils curl \
+    && curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-i18n-${GLIBC_VER}.apk \
+    && apk add --no-cache --virtual .glibc \
+        glibc-${GLIBC_VER}.apk \
+        glibc-bin-${GLIBC_VER}.apk \
+        glibc-i18n-${GLIBC_VER}.apk \
+    && /usr/glibc-compat/bin/localedef -i en_US -f UTF-8 en_US.UTF-8 \
+    && curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip -o awscliv2.zip \
+    && unzip awscliv2.zip \
+    && aws/install \
+    && rm -rf \
+        awscliv2.zip \
+        aws \
+        /usr/local/aws-cli/v2/*/dist/aws_completer \
+        /usr/local/aws-cli/v2/*/dist/awscli/data/ac.index \
+        /usr/local/aws-cli/v2/*/dist/awscli/examples \
+        glibc-*.apk \
+    && apk del --purge .dependencies
+
+COPY --from=cli_builder /build/cloud-platform /usr/local/bin/cloud-platform
+COPY --from=cli_builder /build/kubectl /usr/local/bin/kubectl
+COPY --from=cli_builder /build/terraform /usr/local/bin/terraform
+
+CMD /bin/sh


### PR DESCRIPTION
The aws cli on an newer alpine image is a source of controversy. Version 2 can no longer be built this way, so I decided to restructure the image to decrease the size. This change chops the image size from 700+ MB to just over 300.