### PR TITLE
build: :recycle: Use debian bullseye image in place of alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,82 +1,47 @@
-# Build Cloud Platform tools (CLI)
-FROM golang:1.17-alpine AS cli_builder
+FROM golang:1.17 AS cli_builder
 
-ENV \
-    CGO_ENABLED=0 \
-    GOOS=linux \
-    KUBECTL_VERSION=1.20.7 \
-    TERRAFORM_VERSION=0.14.8
+WORKDIR /app
 
-WORKDIR /build
-
-RUN \
-  apk add \
-    --no-cache \
-    --no-progress \
-    --update \
-    curl \
-    unzip
-
-# Build cli
-COPY go.mod .
-COPY go.sum .
+COPY go.mod ./
+COPY go.sum ./
 RUN go mod download
 COPY . .
+
 RUN go build -o cloud-platform ./cmd/cloud-platform/main.go
 
-# Install kubectl
-RUN curl -sLo ./kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+# ---------------------------------------------------------------------------------------------------------------------
+FROM debian:bullseye as tools_builder
+ENV \
+  KUBECTL_VERSION=1.20.7 \
+  TERRAFORM_VERSION=0.14.8
 
-# Install terraform
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y gnupg software-properties-common curl unzip
+
 RUN curl -sLo terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && unzip terraform.zip
 
-RUN chmod +x kubectl terraform
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && chmod +x kubectl
 
-# ---
+# ---------------------------------------------------------------------------------------------------------------------
+FROM debian:bullseye-slim
 
-FROM alpine:3.14
+WORKDIR /app
 
-ENV AWSCLI_VERSION=2.2.41
-ENV GLIBC_VER=2.31-r0
-
-RUN apk add --update --no-cache \
-  groff \
-  bash \
-  ca-certificates \
-  coreutils \
-  findutils \
-  git-crypt \
-  git \
-  gnupg \
-  grep \
-  openssl
+RUN apt-get update && apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    gnupg-agent \
+    software-properties-common \
+    git-crypt \
+    git \
+    awscli
 
 
-# AWS cli installation taken from https://github.com/aws/aws-cli/issues/4685#issuecomment-941927371
-RUN apk add --no-cache --virtual .dependencies binutils curl \
-    && curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
-    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk \
-    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk \
-    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-i18n-${GLIBC_VER}.apk \
-    && apk add --no-cache --virtual .glibc \
-        glibc-${GLIBC_VER}.apk \
-        glibc-bin-${GLIBC_VER}.apk \
-        glibc-i18n-${GLIBC_VER}.apk \
-    && /usr/glibc-compat/bin/localedef -i en_US -f UTF-8 en_US.UTF-8 \
-    && curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip -o awscliv2.zip \
-    && unzip awscliv2.zip \
-    && aws/install \
-    && rm -rf \
-        awscliv2.zip \
-        aws \
-        /usr/local/aws-cli/v2/*/dist/aws_completer \
-        /usr/local/aws-cli/v2/*/dist/awscli/data/ac.index \
-        /usr/local/aws-cli/v2/*/dist/awscli/examples \
-        glibc-*.apk \
-    && apk del --purge .dependencies
+COPY --from=cli_builder /app/cloud-platform /usr/local/bin/cloud-platform
 
-COPY --from=cli_builder /build/cloud-platform /usr/local/bin/cloud-platform
-COPY --from=cli_builder /build/kubectl /usr/local/bin/kubectl
-COPY --from=cli_builder /build/terraform /usr/local/bin/terraform
+COPY --from=tools_builder /app/terraform /usr/local/bin/terraform
 
-CMD /bin/sh
+COPY --from=tools_builder /app/kubectl /usr/local/bin/kubectl
+
+CMD "/bin/sh"

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,7 @@ FROM debian:bullseye-slim
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y \
-    apt-transport-https \
-    ca-certificates \
     gnupg-agent \
-    software-properties-common \
     git-crypt \
     git \
     awscli
@@ -44,4 +41,4 @@ COPY --from=tools_builder /app/terraform /usr/local/bin/terraform
 
 COPY --from=tools_builder /app/kubectl /usr/local/bin/kubectl
 
-CMD "/bin/sh"
+CMD [/bin/sh]


### PR DESCRIPTION
To make this dockerfile easier to read and maintain it has been split into three stages. Stage one builds the cli. Two builds kubectl and terraform and stage three pulls them altogether and installs the aws cli. The compromise is that the image is now twice as big (around 700MB)