### PR TITLE
Amend only the default node group and add more protection

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -11,6 +11,7 @@ type Cluster struct {
 	Nodes      []v1.Node
 	Pods       []v1.Pod
 	OldestNode v1.Node
+	NewestNode v1.Node
 	StuckPods  []v1.Pod
 }
 
@@ -27,7 +28,7 @@ func NewCluster(c *client.Client) (*Cluster, error) {
 		return nil, err
 	}
 
-	nodes, err := getAllNodes(c)
+	nodes, err := GetAllNodes(c)
 	if err != nil {
 		return nil, err
 	}
@@ -37,11 +38,17 @@ func NewCluster(c *client.Client) (*Cluster, error) {
 		return nil, err
 	}
 
+	newestNode, err := GetNewestNode(c, nodes)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Cluster{
 		Name:       nodes[0].Labels["Cluster"],
 		Pods:       pods,
 		Nodes:      nodes,
 		OldestNode: oldestNode,
+		NewestNode: newestNode,
 	}, nil
 }
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -62,7 +62,7 @@ func (c *Cluster) NewSnapshot() *Snapshot {
 // RefreshStatus performs a value overwrite of the cluster status.
 // This is useful for when the cluster is being updated.
 func (c *Cluster) RefreshStatus(client *client.Client) (err error) {
-	c.Nodes, err = getAllNodes(client)
+	c.Nodes, err = GetAllNodes(client)
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/node.go
+++ b/pkg/cluster/node.go
@@ -121,6 +121,20 @@ func oldestNode(nodes []v1.Node) (v1.Node, error) {
 	return oldestNode, nil
 }
 
+// GetNodeByName takes a node name and returns the node object that has the newest creation timestamp
+func GetNewestNode(c *client.Client, nodes []v1.Node) (v1.Node, error) {
+	newest := nodes[0]
+	for _, node := range nodes {
+		if node.CreationTimestamp.After(newest.CreationTimestamp.Time) {
+			newest = node
+		}
+	}
+
+	return newest, nil
+}
+
+// DeleteNode takes a node and authenticates to both the cluster and the AWS account.
+// You must have a valid AWS credentials and an aws profile set up in your ~/.aws/credentials file.
 func DeleteNode(client *client.Client, awsProfile, awsRegion string, node *v1.Node) error {
 	err := client.Clientset.CoreV1().Nodes().Delete(context.Background(), node.Name, metav1.DeleteOptions{})
 	if err != nil {

--- a/pkg/cluster/node.go
+++ b/pkg/cluster/node.go
@@ -45,9 +45,9 @@ func (c *Cluster) areNodesReady() error {
 			// There are many conditions that can be true, but we only care about
 			// "Ready" - if it's not true, then there's an issue with the kublet
 			if condition.Type == "Ready" && condition.Status != "True" {
-			return fmt.Errorf("node %s is not ready", node.Name)
+				return fmt.Errorf("node %s is not ready", node.Name)
+			}
 		}
-	}
 	}
 
 	return nil
@@ -66,7 +66,7 @@ func (c *Cluster) CompareNodes(snap *Snapshot) (err error) {
 // ValidateCluster allows callers to validate their cluster
 // object.
 func ValidateNodeHealth(c *client.Client) bool {
-	nodes, err := getAllNodes(c)
+	nodes, err := GetAllNodes(c)
 	if err != nil {
 		return false
 	}
@@ -80,8 +80,8 @@ func ValidateNodeHealth(c *client.Client) bool {
 	return true
 }
 
-// getAllNodes returns a slice of all nodes in a cluster
-func getAllNodes(c *client.Client) ([]v1.Node, error) {
+// GetAllNodes returns a slice of all nodes in a cluster
+func GetAllNodes(c *client.Client) ([]v1.Node, error) {
 	n := make([]v1.Node, 0)
 	nodes, err := c.Clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
@@ -93,7 +93,7 @@ func getAllNodes(c *client.Client) ([]v1.Node, error) {
 
 // getOldestNode returns the oldest node in a cluster
 func getOldestNode(c *client.Client) (v1.Node, error) {
-	nodes, err := getAllNodes(c)
+	nodes, err := GetAllNodes(c)
 	if err != nil {
 		return v1.Node{}, err
 	}

--- a/pkg/cluster/node_test.go
+++ b/pkg/cluster/node_test.go
@@ -303,3 +303,69 @@ func Test_oldestNode(t *testing.T) {
 		})
 	}
 }
+
+func TestGetNewestNode(t *testing.T) {
+	var (
+		timeNow = time.Now()
+	)
+	type args struct {
+		c     *client.Client
+		nodes []v1.Node
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    v1.Node
+		wantErr bool
+	}{
+		{
+			name: "GetNewestNode",
+			args: args{
+				c: mockClient,
+				nodes: []v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							CreationTimestamp: metav1.Time{
+								Time: timeNow,
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							CreationTimestamp: metav1.Time{
+								Time: time.Now().Add(-time.Minute),
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							CreationTimestamp: metav1.Time{
+								Time: time.Now().Add(-time.Minute * 2),
+							},
+						},
+					},
+				},
+			},
+			want: v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Time{
+						Time: timeNow,
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetNewestNode(tt.args.c, tt.args.nodes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetNewestNode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetNewestNode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cluster/node_test.go
+++ b/pkg/cluster/node_test.go
@@ -91,8 +91,8 @@ func TestCluster_areNodesReady(t *testing.T) {
 						Status: v1.NodeStatus{
 							Conditions: []v1.NodeCondition{
 								{
-									Type:   v1.NodeDiskPressure,
-									Status: v1.ConditionTrue,
+									Type:   v1.NodeReady,
+									Status: v1.ConditionFalse,
 								},
 							},
 						},

--- a/pkg/cluster/node_test.go
+++ b/pkg/cluster/node_test.go
@@ -198,7 +198,7 @@ func Test_oldestNode(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "OldestNode",
+			name: "FindOldestNode",
 			args: args{
 				nodes: []v1.Node{
 					{
@@ -228,6 +228,62 @@ func Test_oldestNode(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					CreationTimestamp: metav1.Time{
 						Time: timeOldest,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "IfTainted",
+			args: args{
+				nodes: []v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							CreationTimestamp: metav1.Time{
+								Time: timeNow,
+							},
+						},
+						Spec: v1.NodeSpec{
+							Taints: []v1.Taint{
+								{
+									Key:    "key",
+									Value:  "value",
+									Effect: v1.TaintEffectNoSchedule,
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							CreationTimestamp: metav1.Time{
+								Time: timeMinus,
+							},
+						},
+						Spec: v1.NodeSpec{
+							Taints: []v1.Taint{
+								{
+									Key:    "monitoring-node",
+									Value:  "value",
+									Effect: v1.TaintEffectNoSchedule,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Time{
+						Time: timeNow,
+					},
+				},
+				Spec: v1.NodeSpec{
+					Taints: []v1.Taint{
+						{
+							Key:    "key",
+							Value:  "value",
+							Effect: v1.TaintEffectNoSchedule,
+						},
 					},
 				},
 			},

--- a/pkg/cluster/node_test.go
+++ b/pkg/cluster/node_test.go
@@ -41,7 +41,7 @@ func Test_GetAllNodes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getAllNodes(tt.args.c)
+			got, err := GetAllNodes(tt.args.c)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getAllNodes() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -13,7 +13,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.14.1"
+var Version = "1.14.2"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"

--- a/pkg/recycle/drain.go
+++ b/pkg/recycle/drain.go
@@ -97,7 +97,7 @@ func (r *Recycler) addLabel(key, value string) error {
 	return err
 }
 
-// defineResource ensures the Recycler process is populated with the correct node to recycle.
+// useNode ensures the Recycler process is populated with the correct node to recycle.
 func (r *Recycler) useNode() (err error) {
 	if r.Options.Oldest {
 		r.nodeToRecycle = &r.Cluster.OldestNode

--- a/pkg/recycle/drain.go
+++ b/pkg/recycle/drain.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"time"
 
 	"github.com/ministryofjustice/cloud-platform-cli/pkg/cluster"
 	"github.com/rs/zerolog/log"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubectl/pkg/drain"
@@ -20,11 +22,14 @@ func (r *Recycler) getDrainHelper() *drain.Helper {
 		Force:               r.Options.Force,
 		GracePeriodSeconds:  -1,
 		IgnoreAllDaemonSets: true,
-		Out:                 log.Logger,
+		Out:                 ioutil.Discard,
 		ErrOut:              log.Logger,
 		// We want to proceed even when pods are using emptyDir volumes
 		DeleteEmptyDirData: true,
 		Timeout:            time.Duration(r.Options.TimeOut) * time.Second,
+		OnPodDeletedOrEvicted: func(pod *v1.Pod, true bool) {
+			log.Debug().Msgf("Evicting pod %s", pod.Name)
+		},
 	}
 }
 

--- a/pkg/recycle/recycle.go
+++ b/pkg/recycle/recycle.go
@@ -71,7 +71,7 @@ func (r *Recycler) Node() (err error) {
 	}
 
 	log.Info().Msgf("Checking cluster: %s is in a valid state to recycle node", r.Cluster.Name)
-	err = r.validate()
+	err = r.Cluster.HealthCheck()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/3361 and relates to the requirement to only recycle nodes from the default node group. This decision was taken as Prometheus appears to take over ten mins to restart, and for reasons we cannot mitigate that.

It also contains a catch for failing nodes, or nodes in a "not ready" state.