### PR TITLE
Catch incorrect AWS credentials passed to a session

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1,6 +1,8 @@
 package cluster
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/ministryofjustice/cloud-platform-cli/pkg/client"
 	v1 "k8s.io/api/core/v1"
 )
@@ -18,6 +20,13 @@ type Cluster struct {
 // Snapshot represents a snapshot of a Kubernetes cluster object
 type Snapshot struct {
 	Cluster Cluster
+}
+
+// AwsCredentials represents the AWS credentials used to connect to an AWS account.
+type AwsCredentials struct {
+	Session *session.Session
+	Profile string
+	Region  string
 }
 
 // NewCluster creates a new Cluster object and populates its
@@ -57,6 +66,19 @@ func (c *Cluster) NewSnapshot() *Snapshot {
 	return &Snapshot{
 		Cluster: *c,
 	}
+}
+
+// NewAwsCredentials constructs and populates a new AwsCredentials object
+func NewAwsCreds(region string) (*AwsCredentials, error) {
+	sess, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	if err != nil {
+		return nil, err
+	}
+
+	return &AwsCredentials{
+		Session: sess,
+		Region:  region,
+	}, nil
 }
 
 // RefreshStatus performs a value overwrite of the cluster status.

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -65,3 +65,31 @@ func Test_getClusterName(t *testing.T) {
 		})
 	}
 }
+
+func TestNewAwsCreds(t *testing.T) {
+	type args struct {
+		region string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "NewAwsCreds",
+			args: args{
+				region: "us-east-1",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewAwsCreds(tt.args.region)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewAwsCreds() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/pkg/cluster/node_test.go
+++ b/pkg/cluster/node_test.go
@@ -148,38 +148,6 @@ func TestCluster_CompareNodes(t *testing.T) {
 	}
 }
 
-func TestCluster_DeleteNode(t *testing.T) {
-	type args struct {
-		client     *client.Client
-		awsProfile string
-		awsRegion  string
-		node       *v1.Node
-	}
-	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
-	}{
-		{
-			name: "failDeleteNode",
-			args: args{
-				client:     mockClient,
-				awsProfile: "",
-				awsRegion:  "",
-				node:       &v1.Node{},
-			},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := DeleteNode(tt.args.client, tt.args.awsProfile, tt.args.awsRegion, tt.args.node); (err != nil) != tt.wantErr {
-				t.Errorf("Cluster.DeleteNode() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
 func Test_oldestNode(t *testing.T) {
 	var (
 		timeNow    = time.Now()

--- a/pkg/commands/bumpModules.go
+++ b/pkg/commands/bumpModules.go
@@ -1,1 +1,0 @@
-package commands

--- a/pkg/commands/cluster.go
+++ b/pkg/commands/cluster.go
@@ -91,6 +91,8 @@ var clusterRecycleNodeCmd = &cobra.Command{
 
 		err = recycle.Node()
 		if err != nil {
+			// Fail hard so we get an non-zero exit code.
+			// This is mainly for when this is run in a pipeline.
 			contextLogger.Error(err)
 		}
 

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -13,7 +13,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.14.2"
+var Version = "1.14.3"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"

--- a/pkg/recycle/drain.go
+++ b/pkg/recycle/drain.go
@@ -54,7 +54,7 @@ func (r *Recycler) drainNode(helper *drain.Helper) error {
 }
 
 func (r *Recycler) terminateNode() error {
-	err := cluster.DeleteNode(r.Client, r.Options.AwsProfile, r.Options.AwsRegion, r.nodeToRecycle)
+	err := cluster.DeleteNode(r.Client, *r.AwsCreds, r.nodeToRecycle)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR catches a condition where a user either passes incorrect aws credentials or nothing at all. By removing the need to specify an AWS profile, we rely on the end user to pass the AWS credentials via environment variables.