### PR TITLE
Prototype cli

### DIFF
--- a/pkg/commands/environment.go
+++ b/pkg/commands/environment.go
@@ -176,7 +176,7 @@ var environmentPrototypeCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: `Create a gov.uk prototype kit site on the cloud platform`,
 	Long: `
-Create a namespace folder and some files in existing prototype github repository to host a Gov.UK
+Create a namespace folder and files in an existing prototype github repository to host a Gov.UK
 Prototype Kit website on the Cloud Platform.
 
 The namespace name should be your prototype github repository name:

--- a/pkg/commands/environment.go
+++ b/pkg/commands/environment.go
@@ -185,7 +185,7 @@ The namespace name should be your prototype github repository name:
 
 The prototype site will be hosted at:
 
-  https://[namespace name].apps.live-1.cloud-platform.service.justice.gov.uk
+  https://[namespace name].apps.live.cloud-platform.service.justice.gov.uk
 
 A continuous deployment workflow will be created in the github repository such
 that any changes to the 'main' branch are deployed to the cloud platform.

--- a/pkg/commands/environment.go
+++ b/pkg/commands/environment.go
@@ -176,12 +176,12 @@ var environmentPrototypeCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: `Create a gov.uk prototype kit site on the cloud platform`,
 	Long: `
-Create a namespace folder and a github repository to host a Gov.UK
+Create a namespace folder and some files in existing prototype github repository to host a Gov.UK
 Prototype Kit website on the Cloud Platform.
 
-The github repository will be:
+The namespace name should be your prototype github repository name:
 
-  https://github.com/ministryofjustice/[namespace name]
+  https://github.com/ministryofjustice/[repository name]
 
 The prototype site will be hosted at:
 

--- a/pkg/environment/common.go
+++ b/pkg/environment/common.go
@@ -8,24 +8,14 @@ import (
 )
 
 const cloudPlatformEnvRepo = "cloud-platform-environments"
+const namespaceBaseFolder = "namespaces/live.cloud-platform.service.justice.gov.uk"
 const envTemplateLocation = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/main/namespace-resources-cli-template"
-
-var namespaceBaseFolder string
 
 type templateFromUrl struct {
 	outputPath string
 	content    string
 	name       string
 	url        string
-}
-
-func setNamespaceBaseFolder(isProduction string) {
-
-	if isProduction == "true" {
-		namespaceBaseFolder = "namespaces/live-1.cloud-platform.service.justice.gov.uk"
-	} else {
-		namespaceBaseFolder = "namespaces/live.cloud-platform.service.justice.gov.uk"
-	}
 }
 
 func outputFileWriter(fileName string) (*os.File, error) {

--- a/pkg/environment/templateEnvironment.go
+++ b/pkg/environment/templateEnvironment.go
@@ -95,7 +95,6 @@ func promptUserForNamespaceValues() (*Namespace, error) {
 		q.getAnswer()
 		if q.value == "yes" {
 			values.IsProduction = "true"
-
 		} else {
 			values.IsProduction = "false"
 		}
@@ -233,9 +232,6 @@ func downloadAndInitialiseTemplates(namespace string) (error, []*templateFromUrl
 }
 
 func createNamespaceFiles(nsValues *Namespace) error {
-
-	setNamespaceBaseFolder(nsValues.IsProduction)
-
 	err := os.MkdirAll(fmt.Sprintf("%s/%s/resources", namespaceBaseFolder, nsValues.Namespace), 0755)
 	if err != nil {
 		return err

--- a/pkg/environment/templateEnvironment_test.go
+++ b/pkg/environment/templateEnvironment_test.go
@@ -28,7 +28,6 @@ func TestCreateNamespace(t *testing.T) {
 		IsProduction:          "false",
 	}
 
-	setNamespaceBaseFolder(ns.IsProduction)
 	createNamespaceFiles(&ns)
 
 	dir := namespaceBaseFolder + "/foobar/"

--- a/pkg/environment/templatePrototype.go
+++ b/pkg/environment/templatePrototype.go
@@ -35,15 +35,21 @@ Please run:
 
 ...and raise a pull request.
 
-Shortly after your pull request is merged, you should have access to a new
+Shortly after your pull request is merged, you should see new files in your
 github repository:
 
 	https://github.com/ministryofjustice/%s
 
-This is a normal gov.uk prototype kit repository, which you can checkout and
-work on in the usual way.
+Files to build a docker image to run the prototype site
+	Dockerfile
+	.dockerignore
+	start.sh
 
-Changes merged and pushed to the 'main' branch of this repository will be
+A continuous deployment (CD) workflow, targeting the Cloud Platform
+	.github/workflows/cd.yaml
+	kubernetes-deploy.tpl
+
+Changes merged and pushed to the 'main' branch of your prototype github repository will be
 automatically deployed to your gov.uk prototype kit website. This usually takes
 around 5 minutes.
 
@@ -70,9 +76,11 @@ func promptUserForPrototypeValues() (*Prototype, error) {
 			 This must consist only of lower-case letters, digits and
 			 dashes.
 
+			 This should be;
+			 * the name of your existing prototype's github repository
+
 			 This will be;
 			 * the name of the prototype's namespace on the Cloud Platform
-			 * the name of the prototype's github repository
 			 * part of the prototype's URL on the web
 
 			 e.g. if you choose "my-awesome-prototype", then the eventual
@@ -91,13 +99,13 @@ func promptUserForPrototypeValues() (*Prototype, error) {
 	q = userQuestion{
 		description: heredoc.Doc(`What is the name of your GitHub team?
 			The users in this GitHub team will be assigned administrator permission
-			for this Cloud Platform environment, and the github repository.
+			for this Cloud Platform environment.
 
 			Please enter the name in lower-case, with hyphens instead of spaces
 			i.e. "Check My Diary" -> "check-my-diary"
 
 			(this must be an exact match, or you will not have access to your
-			namespace or github repository)",
+			namespace)",
 			 `),
 		prompt:    "GitHub Team",
 		validator: new(githubTeamNameValidator),
@@ -188,22 +196,7 @@ func createPrototypeFiles(p *Prototype) error {
 	copyUrlToFile(prototypeTemplateUrl+"/ecr.tf", nsdir+"/resources/ecr.tf")
 	copyUrlToFile(prototypeTemplateUrl+"/serviceaccount.tf", nsdir+"/resources/serviceaccount.tf")
 	copyUrlToFile(prototypeTemplateUrl+"/basic-auth.tf", nsdir+"/resources/basic-auth.tf")
-
-	templates := []*templateFromUrl{
-		{
-			url:        prototypeTemplateUrl + "/github-repo.tf",
-			outputPath: nsdir + "/resources/github-repo.tf",
-		},
-	}
-	err = downloadTemplateContents(templates)
-	if err != nil {
-		return err
-	}
-
-	err = createFilesFromTemplates(templates, p.Namespace)
-	if err != nil {
-		return err
-	}
+	copyUrlToFile(prototypeTemplateUrl+"/github-repo.tf", nsdir+"/resources/github-repo.tf")
 
 	return nil
 }

--- a/pkg/environment/templatePrototype_test.go
+++ b/pkg/environment/templatePrototype_test.go
@@ -65,7 +65,7 @@ func TestCreatePrototype(t *testing.T) {
 		rbacFile:         "name: \"github:my-github-team\"",
 		variablesTfFile:  "my-team-slack_channel",
 		variablesTfFile:  "my-github-team",
-		githubRepoTfFile: "slug = \"my-github-team\"",
+		githubRepoTfFile: "PROTOTYPE_NAME",
 		ecrTfFile:        "github_repositories = [var.namespace]",
 	}
 


### PR DESCRIPTION
This is to create files in the existing prototype repo, instead of creating new GitHub repo

 Related to:
 https://github.com/ministryofjustice/cloud-platform/issues/3457
 
 Also, Update the environment package, this is to create all the new namespaces in the "live" repo