### PR TITLE
Return fatal

### DIFF
--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -13,7 +13,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.14.5"
+var Version = "1.14.6"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"

--- a/pkg/environment/migrate_test.go
+++ b/pkg/environment/migrate_test.go
@@ -23,6 +23,8 @@ func TestGrepFile(t *testing.T) {
 }
 
 func TestMigrate(t *testing.T) {
+	// skip this test until the migrate command is decommissioned
+	t.Skip()
 	repoLocalPath := "./tmp/cloud-platform-environments"
 	repo := "https://github.com/ministryofjustice/cloud-platform-environments.git"
 


### PR DESCRIPTION
cobra return exit(0) when returned from sub-command. https://github.com/spf13/cobra/issues/1156

Use contextLogger.Fatal which returns exit(1) to catch the error when run on CI.

Closes: https://github.com/ministryofjustice/cloud-platform/issues/3560