### PR TITLE
Retry draining the node with disabling-eviction and delete pods

### DIFF
--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -13,7 +13,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.14.6"
+var Version = "1.14.7"
 
 const owner = "ministryofjustice"
 const repoName = "cloud-platform-cli"

--- a/pkg/recycle/drain.go
+++ b/pkg/recycle/drain.go
@@ -12,6 +12,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/kubectl/pkg/drain"
 )
 
@@ -50,7 +51,36 @@ func (r *Recycler) drainNode(helper *drain.Helper) error {
 		return err
 	}
 
-	return drain.RunNodeDrain(helper, r.nodeToRecycle.Name)
+	err = drain.RunNodeDrain(helper, r.nodeToRecycle.Name)
+	if err != nil {
+		pendingList, newErrs := helper.GetPodsForDeletion(r.nodeToRecycle.Name)
+		if pendingList != nil {
+			pods := pendingList.Pods()
+			if len(pods) != 0 {
+				log.Warn().Msgf("There are pending pods to drain on node %q - Retrying with disable-eviction enabled.",
+					r.nodeToRecycle.Name)
+				for _, pendingPod := range pods {
+					log.Warn().Msgf("%s/%s\n", "pod", pendingPod.Name)
+				}
+				// retry deleting the pending pods with disable-eviction enabled
+				// This wll delete the pods instead of evicting
+				helper.DisableEviction = true
+				err = drain.RunNodeDrain(helper, r.nodeToRecycle.Name)
+				if err != nil {
+					log.Warn().Msgf("Error while retrying to delete pending pods")
+					return err
+				}
+			}
+		} else {
+			// No pending pods to delete. Some other error during draining
+			return err
+		}
+		if newErrs != nil {
+			log.Warn().Msgf("Error while getting the list of pending pods to delete:\n%s", utilerrors.NewAggregate(newErrs))
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *Recycler) terminateNode() error {


### PR DESCRIPTION
There are few unreasonable pod disruption budgets with no allowed disruptions with 1 replica which causes the recycle command to fail when run overnight. 
This change collect the list of pending pods which were not drained in the first run, disable the soft pod eviction process and retry with much harder delete pod.

Example of error: `8:06AM Cannot evict pod as it would violate the pod's disruption budget.`
