### PR TITLE
style(gofumpt): run opinionated linter against codebase

### DIFF
--- a/pkg/cluster/node_test.go
+++ b/pkg/cluster/node_test.go
@@ -273,9 +273,7 @@ func Test_oldestNode(t *testing.T) {
 }
 
 func TestGetNewestNode(t *testing.T) {
-	var (
-		timeNow = time.Now()
-	)
+	timeNow := time.Now()
 	type args struct {
 		c     *client.Client
 		nodes []v1.Node

--- a/pkg/commands/cluster.go
+++ b/pkg/commands/cluster.go
@@ -15,9 +15,7 @@ import (
 
 var opt recycle.Options
 
-var (
-	awsSecret, awsAccessKey, awsProfile string
-)
+var awsSecret, awsAccessKey, awsProfile string
 
 func addClusterCmd(topLevel *cobra.Command) {
 	topLevel.AddCommand(clusterCmd)

--- a/pkg/commands/duplicate.go
+++ b/pkg/commands/duplicate.go
@@ -8,16 +8,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	DuplicateIngressNamespace string
-)
+var DuplicateIngressNamespace string
 
 func addDuplicateCmd(topLevel *cobra.Command) {
 	topLevel.AddCommand(duplicateCmd)
 	duplicateCmd.AddCommand(duplicateIngressCmd)
 
 	duplicateIngressCmd.Flags().StringVarP(&DuplicateIngressNamespace, "namespace", "n", "", "Namespace which you want to perform the duplicate resource")
-
 }
 
 var duplicateCmd = &cobra.Command{
@@ -45,10 +42,8 @@ To access the cluster, it assumes that the user has either set the env variable 
 			return nil
 		}
 		return errors.New("requires existing ingress resource name")
-
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		return duplicate.DuplicateIngress(DuplicateIngressNamespace, args[0])
 	},
 }

--- a/pkg/commands/kubecfg.go
+++ b/pkg/commands/kubecfg.go
@@ -16,7 +16,6 @@ func addKubecfgCmd(topLevel *cobra.Command) {
 	kubecfgCmd.AddCommand(kubecfgShowGithubTeamsCmd)
 
 	kubecfgCommonFlags(kubecfgShowGithubTeamsCmd)
-
 }
 
 var kubecfgCmd = &cobra.Command{

--- a/pkg/commands/terraform.go
+++ b/pkg/commands/terraform.go
@@ -11,7 +11,6 @@ import (
 )
 
 func addTerraformCmd(topLevel *cobra.Command) {
-
 	var options terraform.Commander
 
 	rootCmd := &cobra.Command{
@@ -29,7 +28,6 @@ func addTerraformCmd(topLevel *cobra.Command) {
 
 			contextLogger.Info("Executing terraform plan, if there is a drift this program execution will fail")
 			err := options.CheckDivergence()
-
 			if err != nil {
 				contextLogger.Fatal("Error executing plan, either an error or a divergence")
 			}
@@ -51,7 +49,6 @@ func addTerraformCmd(topLevel *cobra.Command) {
 				}
 			} else {
 				err := options.BulkApply()
-
 				if err != nil {
 					contextLogger.Fatal(err)
 				}
@@ -70,19 +67,16 @@ func addTerraformCmd(topLevel *cobra.Command) {
 			if options.BulkTfPaths == "" {
 				contextLogger.Info("Executing terraform plan")
 				err := options.Plan()
-
 				if err != nil {
 					contextLogger.Fatal("Error executing terraform plan - check the outputs")
 				}
 			} else {
 				err := options.BulkPlan()
-
 				if err != nil {
 					contextLogger.Fatal(err)
 				}
 
 			}
-
 		},
 	}
 

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -15,9 +15,11 @@ import (
 // This MUST match the number of the latest release on github
 var Version = "1.14.8"
 
-const owner = "ministryofjustice"
-const repoName = "cloud-platform-cli"
-const binaryName = "cloud-platform"
+const (
+	owner      = "ministryofjustice"
+	repoName   = "cloud-platform-cli"
+	binaryName = "cloud-platform"
+)
 
 func addVersion(topLevel *cobra.Command) {
 	topLevel.AddCommand(&cobra.Command{

--- a/pkg/duplicate/ingress.go
+++ b/pkg/duplicate/ingress.go
@@ -109,7 +109,6 @@ func copyAndChangeIngress(inIngress *v1.Ingress) (*v1.Ingress, error) {
 		if strings.Contains(k, "meta.helm.sh") || strings.Contains(k, "kubectl.kubernetes.io/last-applied-configuration") {
 			delete(duplicateIngress.Annotations, k)
 		}
-
 	}
 
 	duplicateIngress.ObjectMeta.Name = inIngress.ObjectMeta.Name + "-duplicate"

--- a/pkg/environment/businessUnitValidator.go
+++ b/pkg/environment/businessUnitValidator.go
@@ -1,7 +1,6 @@
 package environment
 
-type businessUnitValidator struct {
-}
+type businessUnitValidator struct{}
 
 func (v *businessUnitValidator) isValid(s string) bool {
 	l := inListValidator{

--- a/pkg/environment/common.go
+++ b/pkg/environment/common.go
@@ -7,9 +7,11 @@ import (
 	"text/template"
 )
 
-const cloudPlatformEnvRepo = "cloud-platform-environments"
-const namespaceBaseFolder = "namespaces/live.cloud-platform.service.justice.gov.uk"
-const envTemplateLocation = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/main/namespace-resources-cli-template"
+const (
+	cloudPlatformEnvRepo = "cloud-platform-environments"
+	namespaceBaseFolder  = "namespaces/live.cloud-platform.service.justice.gov.uk"
+	envTemplateLocation  = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/main/namespace-resources-cli-template"
+)
 
 type templateFromUrl struct {
 	outputPath string
@@ -40,7 +42,6 @@ func downloadTemplateContents(t []*templateFromUrl) error {
 }
 
 func downloadTemplate(url string) (string, error) {
-
 	response, err := http.Get(url)
 	if err != nil {
 		return "", err

--- a/pkg/environment/githubTeamNameValidator.go
+++ b/pkg/environment/githubTeamNameValidator.go
@@ -1,7 +1,6 @@
 package environment
 
-type githubTeamNameValidator struct {
-}
+type githubTeamNameValidator struct{}
 
 func (v *githubTeamNameValidator) isValid(s string) bool {
 	r := new(regexValidator)

--- a/pkg/environment/githubUrlValidator.go
+++ b/pkg/environment/githubUrlValidator.go
@@ -1,7 +1,6 @@
 package environment
 
-type githubUrlValidator struct {
-}
+type githubUrlValidator struct{}
 
 func (v *githubUrlValidator) isValid(s string) bool {
 	r := new(regexValidator)

--- a/pkg/environment/lowercaseStringValidator.go
+++ b/pkg/environment/lowercaseStringValidator.go
@@ -1,7 +1,6 @@
 package environment
 
-type lowercaseStringValidator struct {
-}
+type lowercaseStringValidator struct{}
 
 func (v *lowercaseStringValidator) isValid(s string) bool {
 	r := new(regexValidator)

--- a/pkg/environment/migrateCheck.go
+++ b/pkg/environment/migrateCheck.go
@@ -10,7 +10,6 @@ import (
 
 // MigrateCheck check the namespace has the correct externalDNS annotations
 func MigrateCheck(ns string) error {
-
 	if ns == "" {
 		re := RepoEnvironment{}
 

--- a/pkg/environment/namespaceNameValidator.go
+++ b/pkg/environment/namespaceNameValidator.go
@@ -1,7 +1,6 @@
 package environment
 
-type namespaceNameValidator struct {
-}
+type namespaceNameValidator struct{}
 
 func (v *namespaceNameValidator) isValid(s string) bool {
 	r := new(regexValidator)

--- a/pkg/environment/notEmptyValidator.go
+++ b/pkg/environment/notEmptyValidator.go
@@ -2,8 +2,7 @@ package environment
 
 import "fmt"
 
-type notEmptyValidator struct {
-}
+type notEmptyValidator struct{}
 
 func (v *notEmptyValidator) isValid(s string) bool {
 	if s == "" {

--- a/pkg/environment/slackChannelValidator.go
+++ b/pkg/environment/slackChannelValidator.go
@@ -1,7 +1,6 @@
 package environment
 
-type slackChannelValidator struct {
-}
+type slackChannelValidator struct{}
 
 func (v *slackChannelValidator) isValid(s string) bool {
 	r := new(regexValidator)

--- a/pkg/environment/teamEmailValidator.go
+++ b/pkg/environment/teamEmailValidator.go
@@ -1,7 +1,6 @@
 package environment
 
-type teamEmailValidator struct {
-}
+type teamEmailValidator struct{}
 
 func (v *teamEmailValidator) isValid(s string) bool {
 	r := new(regexValidator)

--- a/pkg/environment/templateEnvironment.go
+++ b/pkg/environment/templateEnvironment.go
@@ -42,7 +42,6 @@ func CreateTemplateNamespace(cmd *cobra.Command, args []string) error {
 //------------------------------------------------------------------------------
 
 func promptUserForNamespaceValues() (*Namespace, error) {
-
 	values := Namespace{}
 
 	q := userQuestion{
@@ -232,7 +231,7 @@ func downloadAndInitialiseTemplates(namespace string) (error, []*templateFromUrl
 }
 
 func createNamespaceFiles(nsValues *Namespace) error {
-	err := os.MkdirAll(fmt.Sprintf("%s/%s/resources", namespaceBaseFolder, nsValues.Namespace), 0755)
+	err := os.MkdirAll(fmt.Sprintf("%s/%s/resources", namespaceBaseFolder, nsValues.Namespace), 0o755)
 	if err != nil {
 		return err
 	}

--- a/pkg/environment/templatePrototype.go
+++ b/pkg/environment/templatePrototype.go
@@ -219,7 +219,7 @@ variable "basic-auth-password" {
 `
 	varTf := fmt.Sprintf("%s/%s/resources/variables.tf", namespaceBaseFolder, p.Namespace.Namespace)
 
-	file, err := os.OpenFile(varTf, os.O_APPEND|os.O_WRONLY, 0644)
+	file, err := os.OpenFile(varTf, os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
 		return err
 	}

--- a/pkg/environment/templateServiceaccount_test.go
+++ b/pkg/environment/templateServiceaccount_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestCreateServiceAccountFile(t *testing.T) {
 	filename := "resources/serviceaccount.tf"
-	os.Mkdir("resources", 0755)
+	os.Mkdir("resources", 0o755)
 
 	err := createSvcAccTfFile()
 	if err != nil {

--- a/pkg/environment/templateServiceacount.go
+++ b/pkg/environment/templateServiceacount.go
@@ -6,8 +6,10 @@ import (
 	"github.com/gookit/color"
 )
 
-const svcAccTemplateFile = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-terraform-serviceaccount/main/template/serviceaccount.tmpl"
-const svcAccTfFile = "resources/serviceaccount.tf"
+const (
+	svcAccTemplateFile = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-terraform-serviceaccount/main/template/serviceaccount.tmpl"
+	svcAccTfFile       = "resources/serviceaccount.tf"
+)
 
 // CreateTemplateServiceAccount sets and creates a template file containing all
 // the necessary values to create a serviceaccount resource in Kubernetes. It

--- a/pkg/environment/templatesEcr.go
+++ b/pkg/environment/templatesEcr.go
@@ -7,8 +7,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const ecrTemplateFile = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-terraform-ecr-credentials/main/examples/ecr.tf"
-const ecrTfFile = "resources/ecr.tf"
+const (
+	ecrTemplateFile = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-terraform-ecr-credentials/main/examples/ecr.tf"
+	ecrTfFile       = "resources/ecr.tf"
+)
 
 func CreateTemplateEcr(cmd *cobra.Command, args []string) error {
 	re := RepoEnvironment{}

--- a/pkg/environment/templatesRds.go
+++ b/pkg/environment/templatesRds.go
@@ -7,8 +7,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const rdsTemplateFile = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-terraform-rds-instance/main/example/rds-postgresql.tf"
-const rdsTfFile = "resources/rds.tf"
+const (
+	rdsTemplateFile = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-terraform-rds-instance/main/example/rds-postgresql.tf"
+	rdsTfFile       = "resources/rds.tf"
+)
 
 // CreateTemplateRds creates the terraform files from environment's template folder
 func CreateTemplateRds(cmd *cobra.Command, args []string) error {
@@ -34,5 +36,5 @@ func CreateTemplateRds(cmd *cobra.Command, args []string) error {
 func createRdsTfFile() error {
 	// The rds "template" is actually an example file that we can just save
 	// "as is" into the user's resources/ directory as `rds.tf`
-	return copyUrlToFile(rdsTemplateFile,rdsTfFile)
+	return copyUrlToFile(rdsTemplateFile, rdsTfFile)
 }

--- a/pkg/environment/templatesS3.go
+++ b/pkg/environment/templatesS3.go
@@ -7,8 +7,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const s3TemplateFile = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-terraform-s3-bucket/main/example/s3.tf"
-const s3TfFile = "resources/s3.tf"
+const (
+	s3TemplateFile = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-terraform-s3-bucket/main/example/s3.tf"
+	s3TfFile       = "resources/s3.tf"
+)
 
 // CreateTemplateRds creates the terraform files from environment's template folder
 func CreateTemplateS3(cmd *cobra.Command, args []string) error {

--- a/pkg/environment/trueFalseValidator.go
+++ b/pkg/environment/trueFalseValidator.go
@@ -1,7 +1,6 @@
 package environment
 
-type trueFalseValidator struct {
-}
+type trueFalseValidator struct{}
 
 func (v *trueFalseValidator) isValid(s string) bool {
 	l := inListValidator{

--- a/pkg/environment/yesNoValidator.go
+++ b/pkg/environment/yesNoValidator.go
@@ -1,7 +1,6 @@
 package environment
 
-type yesNoValidator struct {
-}
+type yesNoValidator struct{}
 
 func (v *yesNoValidator) isValid(s string) bool {
 	l := inListValidator{

--- a/pkg/terraform/kubectl.go
+++ b/pkg/terraform/kubectl.go
@@ -11,7 +11,6 @@ import (
 
 // Kubectl creates kubectl command to be executed
 func (s *Commander) Kubectl(args ...string) (*CmdOutput, error) {
-
 	var stdoutBuf bytes.Buffer
 	var stderrBuf bytes.Buffer
 	var exitCode int

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -31,7 +31,6 @@ type Commander struct {
 
 // Terraform creates terraform command to be executed
 func (s *Commander) Terraform(args ...string) (*CmdOutput, error) {
-
 	var stdoutBuf bytes.Buffer
 	var stderrBuf bytes.Buffer
 	var exitCode int
@@ -92,7 +91,6 @@ func (s *Commander) Terraform(args ...string) (*CmdOutput, error) {
 
 // Init executes terraform init.
 func (s *Commander) Init(p bool) error {
-
 	output, err := s.Terraform("init")
 	if err != nil {
 		log.Error(output.Stderr)
@@ -108,7 +106,6 @@ func (s *Commander) Init(p bool) error {
 
 // SelectWs is used to select certain workspace.
 func (s *Commander) SelectWs(ws string) error {
-
 	output, err := s.Terraform("workspace", "select", ws)
 	if err != nil {
 		return err
@@ -211,7 +208,6 @@ func (s *Commander) Apply() error {
 	}
 
 	return err
-
 }
 
 // Plan executes terraform plan
@@ -255,7 +251,6 @@ func (s *Commander) Plan() error {
 	}
 
 	return err
-
 }
 
 // Workspaces return the workspaces within the state.


### PR DESCRIPTION
Overview
---

This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/3766 and relates to the code standarisation in this repository.

What's in this PR?
---

This PR contains the output of the [gofumpt](https://github.com/mvdan/gofumpt) tool. It provides a stricter, opinionated version of gofmt and uses Go idiomatic formatting.