### PR TITLE
Upgrade aws cli to fix invalid apiVersion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN chmod +x kubectl terraform
 
 FROM alpine:3.14
 
-ENV AWSCLI_VERSION=2.2.41
+ENV AWSCLI_VERSION=2.7.6
 ENV GLIBC_VER=2.31-r0
 
 RUN apk add --update --no-cache \

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -13,7 +13,7 @@ import (
 )
 
 // This MUST match the number of the latest release on github
-var Version = "1.14.9"
+var Version = "1.14.10"
 
 const (
 	owner      = "ministryofjustice"


### PR DESCRIPTION
This is to fix pipeline error `'invalid apiVersion client.authentication.k8s.io/v1alpha1'

AWS CLI has an issue with the versions less that 2.6.3 when executing `aws eks update-kubeconfig` and throw invalid apiVersion. This PR is to upgrade the cli and thereby fixing it