### PR TITLE
Add blank profile to user name space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,9 @@ RUN apk add --no-cache --virtual .dependencies binutils curl \
         glibc-*.apk \
     && apk del --purge .dependencies
 
+# Create a blank aws profile to satisfy the aws provider requirements
+RUN mkdir -p /root/.aws && echo "[moj-cp]" > /root/.aws/credentials
+
 COPY --from=cli_builder /build/cloud-platform /usr/local/bin/cloud-platform
 COPY --from=cli_builder /build/kubectl /usr/local/bin/kubectl
 COPY --from=cli_builder /build/terraform /usr/local/bin/terraform


### PR DESCRIPTION
This is to satisfy the terraform providers requirement to use an aws profile after specifying it from a terraform block. As we do this (from the infrastructure repository), we now need to provide this file or it will fail to auth. Please read the following documentation regarding the requirement: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade#changes-to-authentication
