### PR TITLE
Create a sh install script to simplify installing cloud-platform-cli

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ LICENCE
 Dockerfile
 .build-docker-image
 makefile
+install.sh

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+{
+  set -u
+
+  if [ -d "/usr/local/Cellar/cloud-platform-cli" ]; then
+    echo "cloud-platform-cli already installed via Homebrew"
+    cloud-platform version
+    exit
+  fi
+
+  cached_uname=($(uname -sm))
+  kernel_name="${cached_uname[0]}"
+  machine_arch="${cached_uname[1]}"
+
+  case $kernel_name in
+    Darwin)
+      os="darwin" ;;
+    Linux|GNU*)
+      os="linux" ;;
+    *)
+  esac
+
+  case $machine_arch in
+    x86_64)
+      arch="amd64" ;;
+    arm64)
+      arch="arm64" ;;
+    *)
+  esac
+
+  if [ -z ${os+x} ]; then
+    echo "Unsupported OS: this installation script only supports darwin, linux"
+    exit
+  fi
+
+  if [ -z ${arch+x} ]; then
+    echo "Unsupported architecture: this installation script only supports amd64, arm64"
+    exit
+  fi
+
+  # Get os/arch download URL
+  latest_tag=$(curl -sL https://api.github.com/repos/ministryofjustice/cloud-platform-cli/releases/latest | jq -r '.tag_name')
+  download_url="https://github.com/ministryofjustice/cloud-platform-cli/releases/download/${latest_tag}/cloud-platform-cli_${latest_tag}_${os}_${arch}.tar.gz"
+
+  echo "Installing CLI from $download_url"
+
+  # # Install into /usr/local/bin
+  curl -sL "$url" | tar xz -C /usr/local/bin
+
+  # Test the CLI
+  version=$(cloud-platform version)
+  echo "Cloud Platform $version installed!"
+}


### PR DESCRIPTION
This PR creates a sample install script to enable users to install `cloud-platform-cli` using a curl command, such as:

```sh
curl https://raw.githubusercontent.com/ministryofjustice/cloud-platform-cli/66294a747d40f9d966ea844809b55a70631ddd39/install.sh | sh
```

This means a user can install the appropriate OS/Architecture version of cloud-platform-cli without having to know beforehand what version to use.

Currently supports Darwin/Linux and amd64/arm64; and will exit if the CLI is already installed via Homebrew.