### PR TITLE
Change how we version the cli binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.dll
 *.so
 *.dylib
-cloud-platform
+cloud-platform*
 
 # Test binary, built with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 `cloud-platform` is a command-line tool used by the cloud-platform team and tenants to perform actions on the platform, for example:
 
-   - Create environment configuration using a template
-   - Divergences in terraform states
-   - Terraform apply
-   - Others
+- Create environment configuration using a template
+- Divergences in terraform states
+- Terraform apply
+- Others
 
 User documentation is here: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/cloud-platform-cli.html
 
@@ -100,11 +100,13 @@ actions need to be performed.
 
 ## Develop
 
-You will need golang installed (version 1.13 or greater).
+You will need Go installed.
 
 ### Build locally
 
 Run `make` to create a `cloud-platform` binary.
+
+[note] Something worth noting when building locally. You'll need to pass the `--skip-version-check` command to avoid a message about upgrading.
 
 ### Testing
 
@@ -115,8 +117,8 @@ Run `make test` to run the unit tests.
 This project includes a [github action](.github/workflows/build-release.yml) which
 will automatically do the following steps:
 
-* build a new release and make it available in the [github ui]
-* build a new docker image and push it to [docker hub], tagged with the version number
+- build a new release and make it available in the [github ui]
+- build a new docker image and push it to [docker hub], tagged with the version number
 
 In order to trigger this action, push a new tag version like this:
 
@@ -125,7 +127,7 @@ git tag [my new version]
 git push --tags
 ```
 
-The value of this tag **must** be the same as the string value of `Version` in the file `pkg/commands/version.go`
+The value of this tag **must** will be built into the binary `Version` in the file `pkg/commands/version.go`
 
 #### `PreRun` hook
 

--- a/cmd/cloud-platform/.goreleaser.yml
+++ b/cmd/cloud-platform/.goreleaser.yml
@@ -1,33 +1,33 @@
-env:
-  - GO111MODULE=on
+project_name: cloud-platform-cli
+
 before:
   hooks:
     - go mod download
 builds:
-- env:
-    - CGO_ENABLED=0
-  binary: cloud-platform
-  goos:
-    - linux
-    - darwin
-    - windows
-  goarch:
-    - 386
-    - amd64
-    - arm
-    - arm64
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  flags:
-    - -trimpath
-  ldflags:
-    - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{ .CommitDate }} -X main.builtBy=cloud-platform
+  - env:
+      - CGO_ENABLED=0
+    binary: cloud-platform
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - 386
+      - amd64
+      - arm
+      - arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X github.com/ministryofjustice/cloud-platform-cli/pkg/commands.Version={{.Version}} -X github.com/ministryofjustice/cloud-platform-cli/pkg/commands.Commit={{.Commit}} -X github.com/ministryofjustice/cloud-platform-cli/pkg/commands.Date={{ .CommitDate }}
 changelog:
   sort: asc
   filters:
     exclude:
-    - Merge pull request
-    - Merge branch
-    - go mod tidy
+      - Merge pull request
+      - Merge branch
+      - go mod tidy
 brews:
   - tap:
       owner: ministryofjustice
@@ -40,4 +40,4 @@ brews:
     install: |
       bin.install "cloud-platform"
     dependencies:
-    - name: go
+      - name: go

--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ ifneq ($(COMMIT), $(TAG_COMMIT))
 	VERSION := $(VERSION)-next-$(COMMIT)-$(DATE)
 endif
 ifeq ($(VERSION),)
-	VERSION := $(COMMIT)-$(DATA)
+	VERSION := $(COMMIT)-$(DATE)
 endif
 ifneq ($(shell git status --porcelain),)
 	VERSION := $(VERSION)-dirty

--- a/makefile
+++ b/makefile
@@ -1,9 +1,8 @@
 SOURCE_FILES := $(shell find * -name '*.go')
 
 cloud-platform: $(SOURCE_FILES)
-	export GO111MODULE=on
 	go mod download
-	go build -o cloud-platform ./cmd/cloud-platform/main.go
+	go build -ldflags "-X github.com/ministryofjustice/cloud-platform-cli/pkg/commands.Version=Makefile" -o cloud-platform ./cmd/cloud-platform/main.go
 
 test:
 	go test ./...

--- a/makefile
+++ b/makefile
@@ -1,8 +1,25 @@
-SOURCE_FILES := $(shell find * -name '*.go')
+TAG_COMMIT := $(shell git rev-list --abbrev-commit --tags --max-count=1)
+TAG := $(shell git describe --abbrev=0 --tags ${TAG_COMMIT} 2>/dev/null || true)
+COMMIT := $(shell git rev-parse --short HEAD)
+DATE := $(shell git log -1 --format=%cd --date=format:"%Y%m%d")
+VERSION := $(TAG:v%=%)
+ifneq ($(COMMIT), $(TAG_COMMIT))
+	VERSION := $(VERSION)-next-$(COMMIT)-$(DATE)
+endif
+ifeq ($(VERSION),)
+	VERSION := $(COMMIT)-$(DATA)
+endif
+ifneq ($(shell git status --porcelain),)
+	VERSION := $(VERSION)-dirty
+endif
 
-cloud-platform: $(SOURCE_FILES)
-	go mod download
-	go build -ldflags "-X github.com/ministryofjustice/cloud-platform-cli/pkg/commands.Version=Makefile" -o cloud-platform ./cmd/cloud-platform/main.go
+FLAGS := -ldflags "-X github.com/ministryofjustice/cloud-platform-cli/pkg/commands.Version=$(VERSION)"
+
+build:
+	go build $(FLAGS) -o cloud-platform-$(VERSION) ./cmd/cloud-platform/main.go
+
+run:
+	go run $(FLAGS) ./cmd/cloud-platform/main.go
 
 test:
 	go test ./...

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -12,8 +12,14 @@ import (
 	"github.com/spf13/viper"
 )
 
-// This MUST match the number of the latest release on github
-var Version = "1.15.1"
+// This value is set at build time. If it doesn't equal the latest
+// version, the user will be prompted to upgrade.
+// To build your binary you must pass
+// the -ldflags "-X github.com/ministryofjustice/cloud-platform-cli/pkg/commands.Version=<version>"
+var (
+	Version      = "testBuild"
+	Commit, Date string
+)
 
 const (
 	owner      = "ministryofjustice"
@@ -24,6 +30,7 @@ const (
 func addVersion(topLevel *cobra.Command) {
 	topLevel.AddCommand(&cobra.Command{
 		Use:    "version",
+		Hidden: true,
 		Short:  `Print version`,
 		PreRun: upgradeIfNotLatest,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -41,7 +48,7 @@ func version() string {
 	if Version == "" {
 		i, ok := debug.ReadBuildInfo()
 		if !ok {
-			return ""
+			return "testBuild"
 		}
 		Version = i.Main.Version
 	}


### PR DESCRIPTION
Overview
---

This PR removes the requirement to "bake" the tag/release version into code. By utilising the Go build flags we can pass the version into the binary at build-time.

Pros:
- No more accidental version mismatches
- Easier instructions for new contributors

Cons:
- When developing locally, we'll have to either pass the version at build/run time or always use the `--skip-version-check` flag.
