### PR TITLE
Add linting and improved testing

### DIFF
--- a/.github/workflows/go-vet-lint-deps.yaml
+++ b/.github/workflows/go-vet-lint-deps.yaml
@@ -1,0 +1,40 @@
+name: go-vet-lint
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "**.go"
+
+jobs:
+  build:
+    name: staticcheck
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout your project with git
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Install Go on the VM running the action.
+      - uses: WillAbides/setup-go-faster@v1.7.0
+        with:
+          go-version: "1.19.x"
+
+      - name: Perform staticcheck on codebase
+        uses: dominikh/staticcheck-action@v1.2.0
+        with:
+          version: "2022.1"
+          install-go: false
+
+      - name: Install gofumpt
+        run: |
+          go install mvdan.cc/gofumpt@latest
+
+      - name: Run gofumpt command
+        run: |
+          gofumpt -l -d ./
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: latest

--- a/.github/workflows/go-vet-lint-deps.yaml
+++ b/.github/workflows/go-vet-lint-deps.yaml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/checkout@v3
 
       # Install Go on the VM running the action.
-      - uses: WillAbides/setup-go-faster@v1.7.0
+      - uses: actions/setup-go@v3
         with:
-          go-version: "1.19.x"
+          go-version: ">=1.19.0"
 
       - name: Perform staticcheck on codebase
         uses: dominikh/staticcheck-action@v1.2.0

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,9 +1,20 @@
 name: Run Tests
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, edited, reopened, synchronize]
-
+    paths-ignore:
+      - "**.md"
+      - ".github/**"
+      - "Makefile"
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+      - ".github/**"
+      - "Makefile"
 jobs:
   run-tests:
     strategy:
@@ -13,16 +24,35 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set up Go 1.18
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
-
       - name: Check out code
         uses: actions/checkout@v3
 
-      - name: Download dependencies
-        run: go mod download
+      # Install Go on the VM running the action.
+      - uses: WillAbides/setup-go-faster@v1.7.0
+        with:
+          go-version: "1.19.x"
 
+      # Install gotestfmt on the VM running the action.
+      - name: Set up gotestfmt
+        uses: haveyoudebuggedit/gotestfmt-action@v2
+        with:
+          # Optional: pass GITHUB_TOKEN to avoid rate limiting.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Run tests with nice formatting. Save the original log in /tmp/gotest.log
       - name: Run tests
-        run: go test -race ./...
+        run: |
+          set -euo pipefail
+          go test -json -race -covermode=atomic -coverprofile=coverage.out -v ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
+
+      # Upload the original go test log as an artifact for later review.
+      - name: Upload test log
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: test-log
+          path: /tmp/gotest.log
+          if-no-files-found: error
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run tests
         run: |
           set -euo pipefail
-          go test -json -race -covermode=atomic -coverprofile=coverage.out -v ./... 2>&1 | tee /tmp/gotest.log
+          go test -json -race -covermode=atomic -coverprofile=coverage.out -v ./... 2>&1 | tee ~/gotest.log
 
       # Upload the original go test log as anhaveyoudebuggedit/gotestfmt-action@v2haveyoudebuggedit/gotestfmt-action@v2 artifact for later review.
       - name: Upload test log
@@ -36,7 +36,7 @@ jobs:
         if: always()
         with:
           name: test-log
-          path: /tmp/gotest.log
+          path: ~/gotest.log
           if-no-files-found: error
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,14 +7,14 @@ on:
     paths-ignore:
       - "**.md"
       - ".github/**"
-      - "Makefile"
+      - "makefile"
   push:
     branches:
       - main
     paths-ignore:
       - "**.md"
       - ".github/**"
-      - "Makefile"
+      - "makefile"
 jobs:
   run-tests:
     strategy:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,26 +20,19 @@ jobs:
         uses: actions/checkout@v3
 
       # Install Go on the VM running the action.
-      - uses: WillAbides/setup-go-faster@v1.7.0
+      - uses: actions/setup-go@v3
         with:
-          go-version: "1.19.x"
-
-      # Install gotestfmt on the VM running the action.
-      - name: Set up gotestfmt
-        uses: haveyoudebuggedit/gotestfmt-action@v2
-        with:
-          # Optional: pass GITHUB_TOKEN to avoid rate limiting.
-          token: ${{ secrets.GITHUB_TOKEN }}
+          go-version: ">=1.19.0"
 
       # Run tests with nice formatting. Save the original log in /tmp/gotest.log
       - name: Run tests
         run: |
           set -euo pipefail
-          go test -json -race -covermode=atomic -coverprofile=coverage.out -v ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
+          go test -json -race -covermode=atomic -coverprofile=coverage.out -v ./... 2>&1 | tee /tmp/gotest.log
 
-      # Upload the original go test log as an artifact for later review.
+      # Upload the original go test log as anhaveyoudebuggedit/gotestfmt-action@v2haveyoudebuggedit/gotestfmt-action@v2 artifact for later review.
       - name: Upload test log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: test-log
@@ -47,4 +40,4 @@ jobs:
           if-no-files-found: error
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,17 +4,9 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, edited, reopened, synchronize]
-    paths-ignore:
-      - "**.md"
-      - ".github/**"
-      - "makefile"
   push:
     branches:
       - main
-    paths-ignore:
-      - "**.md"
-      - ".github/**"
-      - "makefile"
 jobs:
   run-tests:
     strategy:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Cloud Platform Tool CLI
 
 [![Releases](https://img.shields.io/github/release/ministryofjustice/cloud-platform-cli/all.svg?style=flat-square)](https://github.com/ministryofjustice/cloud-platform-cli/releases)
+[![codecov](https://codecov.io/gh/ministryofjustice/cloud-platform-cli/branch/main/graph/badge.svg?token=BUF45279MY)](https://codecov.io/gh/ministryofjustice/cloud-platform-cli)
 
 `cloud-platform` is a command-line tool used by the cloud-platform team and tenants to perform actions on the platform, for example:
 


### PR DESCRIPTION
It occurred to me that we don't perform any linting on PR's. We should follow the opinionated best practice of the popular linter [gofumpt](https://github.com/mvdan/gofumpt), which enforces stricter formatting than gofumpt.

This PR also adds codecov uploads so we get an understanding of the test coverage in our codebase and outputs the tests in a nicer format.
