### PR TITLE
Add "raw" flag to decode-secret sub-command

### DIFF
--- a/pkg/commands/decodeSecret.go
+++ b/pkg/commands/decodeSecret.go
@@ -29,5 +29,7 @@ $ cloud-platform decode-secret -n mynamespace -s mysecret
 
 	cmd.Flags().BoolVarP(&opts.ExportAwsCreds, "export-aws-credentials", "e", false, "Export AWS credentials as shell variables")
 
+	cmd.Flags().BoolVarP(&opts.Raw, "raw", "r", false, "Output the raw secret, rather than prettyprinting")
+
 	topLevel.AddCommand(cmd)
 }

--- a/pkg/decodeSecret/decodeSecret_test.go
+++ b/pkg/decodeSecret/decodeSecret_test.go
@@ -1,6 +1,7 @@
 package decodeSecret
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -17,7 +18,7 @@ func TestDecodeSecret(t *testing.T) {
 `
 
 	sd := secretDecoder{}
-	actual, err := sd.processJson(jsn)
+	actual, err := sd.processJson(jsn, false)
 	if err != nil || actual != strings.TrimSpace(expected) {
 		t.Errorf("Expected:\n%s\nGot:\n%s\n", expected, actual)
 	}
@@ -34,7 +35,7 @@ func TestBadBase64(t *testing.T) {
 }
 `
 	sd := secretDecoder{}
-	actual, err := sd.processJson(jsn)
+	actual, err := sd.processJson(jsn, false)
 	if err != nil || actual != strings.TrimSpace(expected) {
 		t.Errorf("Expected:\n%s\nGot:\n%s\n", expected, actual)
 	}
@@ -42,7 +43,7 @@ func TestBadBase64(t *testing.T) {
 
 func TestNoSuchSecret(t *testing.T) {
 	sd := secretDecoder{}
-	_, err := sd.processJson("")
+	_, err := sd.processJson("", false)
 	if err == nil {
 		t.Errorf("Expected an error")
 	}
@@ -52,11 +53,22 @@ func TestRecordsAwsSecrets(t *testing.T) {
 	// jsn := `{ "data": { "access_key_id": "myaccesskey", "secret_access_key": "mysecretkey" } }`
 	jsn := `{ "data": { "access_key_id": "bXlhY2Nlc3NrZXk=", "secret_access_key": "bXlzZWNyZXRrZXk=" } }`
 	sd := secretDecoder{}
-	_, err := sd.processJson(jsn)
+	_, err := sd.processJson(jsn, false)
 	if err != nil || sd.AccessKeyID != "myaccesskey" {
 		t.Errorf("Expected:\n%s\nGot:\n%s\n", "myaccesskey", sd.AccessKeyID)
 	}
 	if err != nil || sd.SecretAccessKey != "mysecretkey" {
 		t.Errorf("Expected:\n%s\nGot:\n%s\n", "mysecretkey", sd.SecretAccessKey)
+	}
+}
+
+func TestOutputtingUnicodeSecrets(t *testing.T) {
+	jsn := `{ "data": { "key1": "dGVzdFVuaWNvZGU8Pj9A"} }`
+
+	expected := fmt.Sprintf("key1: testUnicode<>?@\n")
+	sd := secretDecoder{}
+	actual, err := sd.processJson(jsn, true)
+	if err != nil || actual != expected {
+		t.Errorf("\nExpected:%s\nGot:%s\n", expected, actual)
 	}
 }


### PR DESCRIPTION
This commit connects to https://github.com/ministryofjustice/cloud-platform-cli/issues/103 and offers mitigation (not a fix) to a problem where a secret contains a unicode char. We use the stdlib json package to handle a "prettyprint" back to the end user. When doing so, we marshal a raw string into json, which handles UTF-8 only (please see here: https://pkg.go.dev/encoding/json#Marshal). This commit gives the option to specify a `--raw` or `-r` flag to the subcommand and print before marshaling. This loops over all secret values, decodes the base64 and then prints them raw with no formatting applied.
