### PR TITLE
Aliases, completions and improved document generation

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,7 +16,7 @@ jobs:
       - run: go install
         working-directory: cmd/cloud-platform
       - run: rm -r doc/ && mkdir -p doc
-      - run: go run cmd/cloud-platform/main.go --generate-docs
+      - run: go run cmd/cloud-platform/main.go generate-docs --skip-version-check
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: "Update cloud-platform-cli documentation"
+          commit_message: "docs(automated) update generated documentation"

--- a/cmd/cloud-platform/main.go
+++ b/cmd/cloud-platform/main.go
@@ -30,6 +30,7 @@ func main() {
 	docs := &cobra.Command{
 		Use:               "generate-docs",
 		Short:             "Generate markdown docs for the CLI",
+		Hidden:            true,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
 

--- a/doc/cloud-platform.md
+++ b/doc/cloud-platform.md
@@ -16,6 +16,7 @@ cloud-platform [flags]
 ### SEE ALSO
 
 * [cloud-platform cluster](cloud-platform_cluster.md)	 - Cloud Platform cluster actions
+* [cloud-platform completion](cloud-platform_completion.md)	 - Generate the autocompletion script for the specified shell
 * [cloud-platform decode-secret](cloud-platform_decode-secret.md)	 - Decode a kubernetes secret
 * [cloud-platform duplicate](cloud-platform_duplicate.md)	 - Cloud Platform duplicate resource
 * [cloud-platform environment](cloud-platform_environment.md)	 - Cloud Platform Environment actions

--- a/doc/cloud-platform_completion.md
+++ b/doc/cloud-platform_completion.md
@@ -1,0 +1,30 @@
+## cloud-platform completion
+
+Generate the autocompletion script for the specified shell
+
+### Synopsis
+
+Generate the autocompletion script for cloud-platform for the specified shell.
+See each sub-command's help for details on how to use the generated script.
+
+
+### Options
+
+```
+  -h, --help   help for completion
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform](cloud-platform.md)	 - Multi-purpose CLI from the Cloud Platform team
+* [cloud-platform completion bash](cloud-platform_completion_bash.md)	 - Generate the autocompletion script for bash
+* [cloud-platform completion fish](cloud-platform_completion_fish.md)	 - Generate the autocompletion script for fish
+* [cloud-platform completion powershell](cloud-platform_completion_powershell.md)	 - Generate the autocompletion script for powershell
+* [cloud-platform completion zsh](cloud-platform_completion_zsh.md)	 - Generate the autocompletion script for zsh
+

--- a/doc/cloud-platform_completion_bash.md
+++ b/doc/cloud-platform_completion_bash.md
@@ -1,0 +1,49 @@
+## cloud-platform completion bash
+
+Generate the autocompletion script for bash
+
+### Synopsis
+
+Generate the autocompletion script for the bash shell.
+
+This script depends on the 'bash-completion' package.
+If it is not installed already, you can install it via your OS's package manager.
+
+To load completions in your current shell session:
+
+	source <(cloud-platform completion bash)
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+	cloud-platform completion bash > /etc/bash_completion.d/cloud-platform
+
+#### macOS:
+
+	cloud-platform completion bash > $(brew --prefix)/etc/bash_completion.d/cloud-platform
+
+You will need to start a new shell for this setup to take effect.
+
+
+```
+cloud-platform completion bash
+```
+
+### Options
+
+```
+  -h, --help              help for bash
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform completion](cloud-platform_completion.md)	 - Generate the autocompletion script for the specified shell
+

--- a/doc/cloud-platform_completion_fish.md
+++ b/doc/cloud-platform_completion_fish.md
@@ -1,0 +1,40 @@
+## cloud-platform completion fish
+
+Generate the autocompletion script for fish
+
+### Synopsis
+
+Generate the autocompletion script for the fish shell.
+
+To load completions in your current shell session:
+
+	cloud-platform completion fish | source
+
+To load completions for every new session, execute once:
+
+	cloud-platform completion fish > ~/.config/fish/completions/cloud-platform.fish
+
+You will need to start a new shell for this setup to take effect.
+
+
+```
+cloud-platform completion fish [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for fish
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform completion](cloud-platform_completion.md)	 - Generate the autocompletion script for the specified shell
+

--- a/doc/cloud-platform_completion_powershell.md
+++ b/doc/cloud-platform_completion_powershell.md
@@ -1,0 +1,37 @@
+## cloud-platform completion powershell
+
+Generate the autocompletion script for powershell
+
+### Synopsis
+
+Generate the autocompletion script for powershell.
+
+To load completions in your current shell session:
+
+	cloud-platform completion powershell | Out-String | Invoke-Expression
+
+To load completions for every new session, add the output of the above command
+to your powershell profile.
+
+
+```
+cloud-platform completion powershell [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for powershell
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform completion](cloud-platform_completion.md)	 - Generate the autocompletion script for the specified shell
+

--- a/doc/cloud-platform_completion_zsh.md
+++ b/doc/cloud-platform_completion_zsh.md
@@ -1,0 +1,51 @@
+## cloud-platform completion zsh
+
+Generate the autocompletion script for zsh
+
+### Synopsis
+
+Generate the autocompletion script for the zsh shell.
+
+If shell completion is not already enabled in your environment you will need
+to enable it.  You can execute the following once:
+
+	echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+To load completions in your current shell session:
+
+	source <(cloud-platform completion zsh); compdef _cloud-platform cloud-platform
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+	cloud-platform completion zsh > "${fpath[1]}/_cloud-platform"
+
+#### macOS:
+
+	cloud-platform completion zsh > $(brew --prefix)/share/zsh/site-functions/_cloud-platform
+
+You will need to start a new shell for this setup to take effect.
+
+
+```
+cloud-platform completion zsh [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for zsh
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform completion](cloud-platform_completion.md)	 - Generate the autocompletion script for the specified shell
+

--- a/pkg/commands/decodeSecret.go
+++ b/pkg/commands/decodeSecret.go
@@ -9,9 +9,11 @@ import (
 func addDecodeSecret(topLevel *cobra.Command) {
 	opts := &decodeSecret.DecodeSecretOptions{}
 
+	alias := []string{"decode", "secret"}
 	cmd := &cobra.Command{
-		Use:   "decode-secret",
-		Short: `Decode a kubernetes secret`,
+		Use:     "decode-secret",
+		Aliases: alias,
+		Short:   `Decode a kubernetes secret`,
 		Example: heredoc.Doc(`
 $ cloud-platform decode-secret -n mynamespace -s mysecret
 	`),


### PR DESCRIPTION
This PR contains three things, as the title suggests: 

- It creates an alias for the `cloud-platform` command, `moj-cp`.

- It adds the first round of automatic completions to the `cloud-platform` command. This will allow users to perform tab completions when performing commands, such as `cloud-platform environment`. If this is useful, we can expand this offering to all popular commands.

- It improves how you generate the documentation. We introduced automatic document generation in the 1.18 release, and it worked by specifiying a `--generate-docs` flag that was hidden to the end user. This caused issues when leading with a global/parent flag. For example, when running `cloud-platform --skip-version-check version` it would initiate an exit 1 with the error:

```bash
flag provided but not defined: -skip-version-check
Usage of cloud-platform:
  -generate-docs
        generate CLI documentation
```

This is caused by mixing the stdlib flags package with the cobra one. I decided to make this a sub-command that is hidden to the end user.