### PR TITLE
Test the Dockerfile Structure 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,8 @@
 .git
 .github
+.gitignore
+.goreleaser.yml
 LICENCE
 Dockerfile
-.build-docker-image
 makefile
-install.sh
+README.md

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,9 +1,9 @@
-name: "Code quality tests"
+name: Code quality tests
 
 on:
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [main]
     types: [opened, synchronize, reopened]
 
 jobs:
@@ -17,15 +17,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go' ]
+        language: ["go"]
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/docker-tests.yaml
+++ b/.github/workflows/docker-tests.yaml
@@ -12,17 +12,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
       - name: Build
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: false
-          tags: cli-test
-      - name: Check image actually exists
+        run: docker built -t cli-test .
+      - name: Check it exists
         run: docker images
 
       - name: Run docker tests

--- a/.github/workflows/docker-tests.yaml
+++ b/.github/workflows/docker-tests.yaml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build
-        run: docker built -t cli-test .
+        run: docker build -t cli-test .
       - name: Check it exists
         run: docker images
 

--- a/.github/workflows/docker-tests.yaml
+++ b/.github/workflows/docker-tests.yaml
@@ -22,6 +22,8 @@ jobs:
           context: .
           push: false
           tags: cli-test
+      - name: Check image actually exists
+        run: docker images
 
       - name: Run docker tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test:latest

--- a/.github/workflows/docker-tests.yaml
+++ b/.github/workflows/docker-tests.yaml
@@ -3,7 +3,7 @@ on: pull_request
 
 jobs:
   dockerfile-test:
-    name: Install and run container-structure-test
+    name: container-structure-test
     runs-on: ubuntu-latest
 
     steps:
@@ -21,7 +21,7 @@ jobs:
         with:
           context: .
           push: false
-          tags: test-cli
+          tags: cli-test
 
       - name: Run docker tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test:latest

--- a/.github/workflows/docker-tests.yaml
+++ b/.github/workflows/docker-tests.yaml
@@ -24,6 +24,6 @@ jobs:
           tags: test-cli
 
       - name: Run docker tests
-        uses: gcr.io/gcp-runtimes/container-structure-test:latest
+        uses: docker://gcr.io/gcp-runtimes/container-structure-test:latest
         with:
           args: "test --image cli-test --config docker-test.yaml"

--- a/.github/workflows/docker-tests.yaml
+++ b/.github/workflows/docker-tests.yaml
@@ -1,0 +1,29 @@
+name: Test Dockerfile
+on: pull_request
+
+jobs:
+  dockerfile-test:
+    name: Install and run container-structure-test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          tags: test-cli
+
+      - name: Run docker tests
+        uses: gcr.io/gcp-runtimes/container-structure-test:latest
+        with:
+          args: "test --image cli-test --config docker-test.yaml"

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: Test Go code
 
 on:
   workflow_dispatch:
@@ -8,7 +8,7 @@ on:
     branches:
       - main
 jobs:
-  run-tests:
+  go-test:
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ cloud-platform-*
 
 .DS_Store
 completions
+
+# Go test output
+coverage.out

--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ These tests live next to the code, they have no build tag and will run regardles
 
 Run `make test` to run the unit tests.
 
+There are Dockerfile structure tests that run automatically in a pipeline. If you want to run these locally, install the [container-structure-test](https://github.com/GoogleContainerTools/container-structure-test#installation) binary and run:
+
+```bash
+container-structure-test test --image my-image-name \
+--config docker-test.yaml
+```
+
 ### Releasing a new version
 
 This project includes a [github action](.github/workflows/build-release.yml) which

--- a/docker-test.yaml
+++ b/docker-test.yaml
@@ -1,0 +1,21 @@
+schemaVersion: "2.0.0"
+fileExistenceTests:
+  - name: "cloud-platform binary"
+    path: "/usr/local/bin/cloud-platform"
+    shouldExist: true
+  - name: "terraform binary"
+    path: "/usr/local/bin/terraform"
+    shouldExist: true
+  - name: "kubectl binary"
+    path: "/usr/local/bin/kubectl"
+    shouldExist: true
+commandTests:
+  - name: "cloud-platform bad command"
+    command: "cloud-platform"
+    args: ["bad-command"]
+    expectedError: [".*Error.*"]
+    exitCode: 1
+  - name: "cloud-platform good command"
+    command: "cloud-platform"
+    args: ["version", "--skip-version-check"]
+    exitCode: 0


### PR DESCRIPTION
This PR contains two things:

- A method to test the Dockerfile structure works, with an accompanying GitHub action and documentation.
- Linting and other touchups I noticed were needed when working in the repository.

Why do we want to merge?

- Asserting the Dockerfile build and structure will allow us to make faster decisions on dependabot PR's.
- The repository looks cleaner with linting and better naming conventions.