### PR TITLE
Add codecov config and ignore commands package

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default: # This can be anything, but it needs to exist as the name
+        branches:
+          - main
+        ignore:
+          - "pkg/commmands/*" # Cobra commands

--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -5,4 +5,5 @@ coverage:
         branches:
           - main
         ignore:
-          - "pkg/commmands/*" # Cobra commands
+          - "pkg/commmands/*"
+          - "cmd/*"

--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -2,8 +2,6 @@ coverage:
   status:
     project:
       default: # This can be anything, but it needs to exist as the name
-        branches:
-          - main
         ignore:
           - "pkg/commmands/*"
           - "cmd/*"


### PR DESCRIPTION
the commands directory contains Cobra calls. We have other ways of testing the Cobra output, so it makes sense to ask codecov to ignore this directory.
