### PR TITLE
remove config file in defer

### DIFF
--- a/pkg/cluster/create_test.go
+++ b/pkg/cluster/create_test.go
@@ -102,7 +102,14 @@ func TestNewClientset(t *testing.T) {
 		},
 	}
 
-	_, err := newClientset(cluster, "aws", "test")
+	defer func() {
+		err := os.Remove("config")
+		if err != nil {
+			t.Errorf("error removing config file: %v", err)
+		}
+	}()
+
+	_, err := newClientset(cluster, "config", "test")
 	if err == nil {
 		t.Errorf("newClientset() error = %v", err)
 	}


### PR DESCRIPTION
Remove the config file generated by testing. The test leave a left over without this change.