### PR TITLE
fix(goreleaser): Revert goreleaser docker build

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 jobs:
-  cli-build:
+  build:
     name: GoReleaser build
     runs-on: ubuntu-latest
 
@@ -18,12 +18,35 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0 # See: https://goreleaser.com/ci/actions/
-
+      - name: Fetch all tags
+        run: git fetch --force --tags
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: 1.19
         id: go
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+  docker:
+    name: Build container and push to DockerHub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
         uses: docker/login-action@v2
@@ -31,13 +54,17 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
-        if: success() && startsWith(github.ref, 'refs/tags/')
+      - name: Get Tags for Image
+        id: metadata
+        uses: docker/metadata-action@v4
         with:
-          version: latest
-          args: release -f .goreleaser.yml --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          images: ministryofjustice/cloud-platform-cli
+          tags: |
+            type=ref,event=tag
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          build-args: CLOUD_PLATFORM_CLI_VERSION=${{ steps.metadata.outputs.tags }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,83 +49,83 @@ brews:
       fish_completion.install "completions/cloud-platform.fish"
     dependencies:
       - name: go
-dockers:
-  - image_templates: [ "ministryofjustice/{{ .ProjectName }}:{{ .Tag}}-amd64" ]
-    goarch: amd64
-    dockerfile: '{{ .Env.DOCKERFILE }}'
-    use: buildx
-    build_flag_templates:
-      - --build-arg=CLOUD_PLATFORM_CLI_VERSION={{ .Tag}}
-      - --platform=linux/amd64
-      - --label=org.opencontainers.image.title={{ .ProjectName }}
-      - --label=org.opencontainers.image.description={{ .ProjectName }}
-      - --label=org.opencontainers.image.url=https://github.com/ministryofjustice/{{ .ProjectName }}
-      - --label=org.opencontainers.image.source=https://github.com/ministryofjustice/{{ .ProjectName }}
-      - --label=org.opencontainers.image.version={{ .Version }}
-      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
-      - --label=org.opencontainers.image.revision={{ .FullCommit }}
-      - --label=org.opencontainers.image.licenses=MIT License
-  - image_templates: [ "ministryofjustice/{{ .ProjectName }}:{{ .Tag}}-arm64" ]
-    goarch: arm64
-    dockerfile: '{{ .Env.DOCKERFILE }}'
-    use: buildx
-    build_flag_templates:
-      - --build-arg=CLOUD_PLATFORM_CLI_VERSION={{ .Tag}}
-      - --platform=linux/arm64
-      - --label=org.opencontainers.image.title={{ .ProjectName }}
-      - --label=org.opencontainers.image.description={{ .ProjectName }}
-      - --label=org.opencontainers.image.url=https://github.com/ministryofjustice/{{ .ProjectName }}
-      - --label=org.opencontainers.image.source=https://github.com/ministryofjustice/{{ .ProjectName }}
-      - --label=org.opencontainers.image.version={{ .Version }}
-      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
-      - --label=org.opencontainers.image.revision={{ .FullCommit }}
-      - --label=org.opencontainers.image.licenses=MIT License
-  - image_templates: [ "ministryofjustice/{{ .ProjectName }}:{{ .Tag}}-arm" ]
-    goarch: arm
-    dockerfile: '{{ .Env.DOCKERFILE }}'
-    use: buildx
-    build_flag_templates:
-      - --build-arg=CLOUD_PLATFORM_CLI_VERSION={{ .Tag}}
-      - --platform=linux/arm
-      - --label=org.opencontainers.image.title={{ .ProjectName }}
-      - --label=org.opencontainers.image.description={{ .ProjectName }}
-      - --label=org.opencontainers.image.url=https://github.com/ministryofjustice/{{ .ProjectName }}
-      - --label=org.opencontainers.image.source=https://github.com/ministryofjustice/{{ .ProjectName }}
-      - --label=org.opencontainers.image.version={{ .Version }}
-      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
-      - --label=org.opencontainers.image.revision={{ .FullCommit }}
-      - --label=org.opencontainers.image.licenses=MIT License
-  - image_templates: [ "ministryofjustice/{{ .ProjectName }}:{{ .Tag}}-386" ]
-    goarch: "386"
-    dockerfile: '{{ .Env.DOCKERFILE }}'
-    use: buildx
-    build_flag_templates:
-      - --build-arg=CLOUD_PLATFORM_CLI_VERSION={{ .Tag}}
-      - --platform=linux/386
-      - --label=org.opencontainers.image.title={{ .ProjectName }}
-      - --label=org.opencontainers.image.description={{ .ProjectName }}
-      - --label=org.opencontainers.image.url=https://github.com/ministryofjustice/{{ .ProjectName }}
-      - --label=org.opencontainers.image.source=https://github.com/ministryofjustice/{{ .ProjectName }}
-      - --label=org.opencontainers.image.version={{ .Version }}
-      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
-      - --label=org.opencontainers.image.revision={{ .FullCommit }}
-      - --label=org.opencontainers.image.licenses=MIT License
+# dockers:
+#   - image_templates: [ "ministryofjustice/{{ .ProjectName }}:{{ .Tag}}-amd64" ]
+#     goarch: amd64
+#     dockerfile: '{{ .Env.DOCKERFILE }}'
+#     use: buildx
+#     build_flag_templates:
+#       - --build-arg=CLOUD_PLATFORM_CLI_VERSION={{ .Tag}}
+#       - --platform=linux/amd64
+#       - --label=org.opencontainers.image.title={{ .ProjectName }}
+#       - --label=org.opencontainers.image.description={{ .ProjectName }}
+#       - --label=org.opencontainers.image.url=https://github.com/ministryofjustice/{{ .ProjectName }}
+#       - --label=org.opencontainers.image.source=https://github.com/ministryofjustice/{{ .ProjectName }}
+#       - --label=org.opencontainers.image.version={{ .Version }}
+#       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+#       - --label=org.opencontainers.image.revision={{ .FullCommit }}
+#       - --label=org.opencontainers.image.licenses=MIT License
+#   - image_templates: [ "ministryofjustice/{{ .ProjectName }}:{{ .Tag}}-arm64" ]
+#     goarch: arm64
+#     dockerfile: '{{ .Env.DOCKERFILE }}'
+#     use: buildx
+#     build_flag_templates:
+#       - --build-arg=CLOUD_PLATFORM_CLI_VERSION={{ .Tag}}
+#       - --platform=linux/arm64
+#       - --label=org.opencontainers.image.title={{ .ProjectName }}
+#       - --label=org.opencontainers.image.description={{ .ProjectName }}
+#       - --label=org.opencontainers.image.url=https://github.com/ministryofjustice/{{ .ProjectName }}
+#       - --label=org.opencontainers.image.source=https://github.com/ministryofjustice/{{ .ProjectName }}
+#       - --label=org.opencontainers.image.version={{ .Version }}
+#       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+#       - --label=org.opencontainers.image.revision={{ .FullCommit }}
+#       - --label=org.opencontainers.image.licenses=MIT License
+#   - image_templates: [ "ministryofjustice/{{ .ProjectName }}:{{ .Tag}}-arm" ]
+#     goarch: arm
+#     dockerfile: '{{ .Env.DOCKERFILE }}'
+#     use: buildx
+#     build_flag_templates:
+#       - --build-arg=CLOUD_PLATFORM_CLI_VERSION={{ .Tag}}
+#       - --platform=linux/arm
+#       - --label=org.opencontainers.image.title={{ .ProjectName }}
+#       - --label=org.opencontainers.image.description={{ .ProjectName }}
+#       - --label=org.opencontainers.image.url=https://github.com/ministryofjustice/{{ .ProjectName }}
+#       - --label=org.opencontainers.image.source=https://github.com/ministryofjustice/{{ .ProjectName }}
+#       - --label=org.opencontainers.image.version={{ .Version }}
+#       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+#       - --label=org.opencontainers.image.revision={{ .FullCommit }}
+#       - --label=org.opencontainers.image.licenses=MIT License
+#   - image_templates: [ "ministryofjustice/{{ .ProjectName }}:{{ .Tag}}-386" ]
+#     goarch: "386"
+#     dockerfile: '{{ .Env.DOCKERFILE }}'
+#     use: buildx
+#     build_flag_templates:
+#       - --build-arg=CLOUD_PLATFORM_CLI_VERSION={{ .Tag}}
+#       - --platform=linux/386
+#       - --label=org.opencontainers.image.title={{ .ProjectName }}
+#       - --label=org.opencontainers.image.description={{ .ProjectName }}
+#       - --label=org.opencontainers.image.url=https://github.com/ministryofjustice/{{ .ProjectName }}
+#       - --label=org.opencontainers.image.source=https://github.com/ministryofjustice/{{ .ProjectName }}
+#       - --label=org.opencontainers.image.version={{ .Version }}
+#       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+#       - --label=org.opencontainers.image.revision={{ .FullCommit }}
+#       - --label=org.opencontainers.image.licenses=MIT License
 
-docker_manifests: 
-  - name_template: "ministryofjustice/{{ .ProjectName }}:{{ .Tag }}"
-    image_templates:
-      - "ministryofjustice/{{ .ProjectName }}:{{ .Tag }}-amd64"
-      - "ministryofjustice/{{ .ProjectName }}:{{ .Tag }}-arm64"
-      - "ministryofjustice/{{ .ProjectName }}:{{ .Tag }}-arm"
-      - "ministryofjustice/{{ .ProjectName }}:{{ .Tag }}-386"
-  - name_template: "ministryofjustice/{{ .ProjectName }}:latest"
-    image_templates: 
-      - "ministryofjustice/{{ .ProjectName }}:{{ .Tag }}-amd64"
-      - "ministryofjustice/{{ .ProjectName }}:{{ .Tag }}-arm64"
-      - "ministryofjustice/{{ .ProjectName }}:{{ .Tag }}-arm"
-      - "ministryofjustice/{{ .ProjectName }}:{{ .Tag }}-386"
+# docker_manifests: 
+#   - name_template: "ministryofjustice/{{ .ProjectName }}:{{ .Tag }}"
+#     image_templates:
+#       - "ministryofjustice/{{ .ProjectName }}:{{ .Tag }}-amd64"
+#       - "ministryofjustice/{{ .ProjectName }}:{{ .Tag }}-arm64"
+#       - "ministryofjustice/{{ .ProjectName }}:{{ .Tag }}-arm"
+#       - "ministryofjustice/{{ .ProjectName }}:{{ .Tag }}-386"
+#   - name_template: "ministryofjustice/{{ .ProjectName }}:latest"
+#     image_templates: 
+#       - "ministryofjustice/{{ .ProjectName }}:{{ .Tag }}-amd64"
+#       - "ministryofjustice/{{ .ProjectName }}:{{ .Tag }}-arm64"
+#       - "ministryofjustice/{{ .ProjectName }}:{{ .Tag }}-arm"
+#       - "ministryofjustice/{{ .ProjectName }}:{{ .Tag }}-386"
 
-announce:
-  slack:
-    enabled: true
-    message_template: '{{ .ProjectName }} {{ .Tag }}: The latest release has been created successfully: {{ .ReleaseURL }}'
+# announce:
+#   slack:
+#     enabled: true
+#     message_template: '{{ .ProjectName }} {{ .Tag }}: The latest release has been created successfully: {{ .ReleaseURL }}'


### PR DESCRIPTION
goreleaser pipeline error when running the docker build, reverting back to old build method to unblock release of 1.22.3, and to investigate error separately
