### PR TITLE
Increase results page to 100

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -86,7 +86,12 @@ func (gh *GithubClient) ListMergedPRs(date util.Date, count int) ([]Nodes, error
 }
 
 func (gh *GithubClient) GetChangedFiles(prNumber int) ([]*github.CommitFile, error) {
-	repos, _, err := gh.PullRequests.ListFiles(context.Background(), gh.Owner, gh.Repository, prNumber, nil)
+	repos, _, err := gh.PullRequests.ListFiles(
+		context.Background(),
+		gh.Owner,
+		gh.Repository,
+		prNumber,
+		&github.ListOptions{PerPage: 100})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
By default, the method returns only 30 files in that PR. Sometimes, when doing bulk PR, all namespace changes in the PR are not listed. This PR increase the default results to return 100(which is max).
