### PR TITLE
Reduce strings to be redacted in terraform output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 
 require (
 	github.com/aws/aws-sdk-go v1.44.167
+	github.com/dlclark/regexp2 v1.8.1
 	github.com/google/go-cmdtest v0.4.0
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/hashicorp/go-version v1.6.0
@@ -37,6 +38,7 @@ require (
 	github.com/hashicorp/terraform-json v0.14.0
 	github.com/jedib0t/go-pretty/v6 v6.4.3
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/migueleliasweb/go-github-mock v0.0.16
 	github.com/ministryofjustice/cloud-platform-go-library v0.0.0-20220803122921-1ca1153b1730
 	github.com/rs/zerolog v1.29.0
 	github.com/shurcooL/githubv4 v0.0.0-20220922232305-70b4d362a8cb
@@ -46,7 +48,7 @@ require (
 	k8s.io/apimachinery v0.25.2
 	k8s.io/client-go v0.25.2
 	k8s.io/kubectl v0.25.2
-	sigs.k8s.io/aws-iam-authenticator v0.5.10
+	sigs.k8s.io/aws-iam-authenticator v0.6.4
 )
 
 require (
@@ -103,7 +105,6 @@ require (
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
-	github.com/migueleliasweb/go-github-mock v0.0.16 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,7 +95,7 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws/aws-sdk-go v1.44.107/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.44.145/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go v1.44.167 h1:kQmBhGdZkQLU7AiHShSkBJ15zr8agy0QeaxXduvyp2E=
 github.com/aws/aws-sdk-go v1.44.167/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
@@ -139,6 +139,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/dlclark/regexp2 v1.8.1 h1:6Lcdwya6GjPUNsBct8Lg/yRPwMhABj269AAzdGSiR+0=
+github.com/dlclark/regexp2 v1.8.1/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
@@ -767,7 +769,6 @@ golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/net v0.4.0 h1:Q5QPcMlvfxFTAPV0+07Xz/MpK9NTXu2VDUuy0FeMfaU=
@@ -859,7 +860,6 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1136,8 +1136,8 @@ k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/aws-iam-authenticator v0.5.10 h1:YGPh/SpRxNkWXfGkURKGsgWvz70x41SB4QazrU7R3Wk=
-sigs.k8s.io/aws-iam-authenticator v0.5.10/go.mod h1:3oJI6vy91KxVSb9g+v9gtJsFnFDJoq+ySJhGDBKpKFk=
+sigs.k8s.io/aws-iam-authenticator v0.6.4 h1:OLB+aZuT+GeggTr0fCtnqjNIvA/2RmvRwaxbzDHreoU=
+sigs.k8s.io/aws-iam-authenticator v0.6.4/go.mod h1:1cl1kCN0UQX7XEMJ33E0qJqBtLXz04XT92x4h0shNus=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kustomize/api v0.12.1 h1:7YM7gW3kYBwtKvoY216ZzY+8hM+lV53LUayghNRJ0vM=

--- a/pkg/environment/environmentApply.go
+++ b/pkg/environment/environmentApply.go
@@ -253,12 +253,16 @@ func (a *Apply) planNamespace() error {
 	applier := NewApply(*a.Options)
 	repoPath := "namespaces/" + a.Options.ClusterCtx + "/" + a.Options.Namespace
 
-	outputKubectl, err := applier.planKubectl()
-	if err != nil {
-		return err
-	}
+	if util.IsYamlFileExists(repoPath) {
+		outputKubectl, err := applier.planKubectl()
+		if err != nil {
+			return err
+		}
 
-	fmt.Println("\nOutput of kubectl:", outputKubectl)
+		fmt.Println("\nOutput of kubectl:", outputKubectl)
+	} else {
+		fmt.Printf("Namespace %s doesnot have yaml resources folder, skipping kubectl apply --dry-run", a.Options.Namespace)
+	}
 
 	exists, err := util.IsFilePathExists(repoPath + "/resources")
 	if err == nil && exists {
@@ -270,7 +274,7 @@ func (a *Apply) planNamespace() error {
 		fmt.Println("\nOutput of terraform:")
 		util.Redacted(os.Stdout, outputTerraform)
 	} else {
-		return err
+		fmt.Printf("Namespace %s doesnot have yaml resources folder, skipping terraform plan", a.Options.Namespace)
 	}
 	return nil
 }
@@ -323,11 +327,16 @@ func (a *Apply) applyNamespace() error {
 
 	applier := NewApply(*a.Options)
 
-	outputKubectl, err := applier.applyKubectl()
-	if err != nil {
-		return err
+	if util.IsYamlFileExists(repoPath) {
+		outputKubectl, err := applier.applyKubectl()
+		if err != nil {
+			return err
+		}
+
+		fmt.Println("\nOutput of kubectl:", outputKubectl)
+	} else {
+		fmt.Printf("Namespace %s doesnot have yaml resources folder, skipping kubectl apply", a.Options.Namespace)
 	}
-	fmt.Println("\nOutput of kubectl:", outputKubectl)
 
 	exists, err := util.IsFilePathExists(repoPath + "/resources")
 	if err == nil && exists {
@@ -339,8 +348,7 @@ func (a *Apply) applyNamespace() error {
 		fmt.Println("\nOutput of terraform:")
 		util.Redacted(os.Stdout, outputTerraform)
 	} else {
-		log.Printf("Namespace %s doesnot have terraform resources folder, skipping terraform apply", a.Options.Namespace)
-		return err
+		fmt.Printf("Namespace %s doesnot have terraform resources folder, skipping terraform apply", a.Options.Namespace)
 	}
 	return nil
 }

--- a/pkg/util/filesystem.go
+++ b/pkg/util/filesystem.go
@@ -4,6 +4,8 @@ package util
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 )
@@ -102,4 +104,19 @@ func IsFilePathExists(filePath string) (bool, error) {
 	} else {
 		return false, err
 	}
+}
+
+func IsYamlFileExists(path string) bool {
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, file := range files {
+		fileExtension := filepath.Ext(path + "/" + file.Name())
+		if fileExtension == ".yaml" {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/util/filesystem.go
+++ b/pkg/util/filesystem.go
@@ -4,7 +4,6 @@ package util
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -107,7 +106,7 @@ func IsFilePathExists(filePath string) (bool, error) {
 }
 
 func IsYamlFileExists(path string) bool {
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/util/filesystem_test.go
+++ b/pkg/util/filesystem_test.go
@@ -56,3 +56,28 @@ func TestIsFilePathExists(t *testing.T) {
 	}
 	defer os.RemoveAll("namespaces")
 }
+
+func TestIsYamlFileExists(t *testing.T) {
+	tempDir := "namespaces/testCluster/testNamespace"
+	tempFile := tempDir + "/foo.yaml"
+
+	if err := os.MkdirAll(tempDir, os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	got := util.IsYamlFileExists(tempDir)
+	if got {
+		t.Errorf("Expected no yaml file %v got %v", tempFile, got)
+	}
+
+	_, err := os.Create(tempFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got = util.IsYamlFileExists(tempDir)
+	if !got {
+		t.Errorf("Expected file %v not found", tempFile)
+	}
+	defer os.RemoveAll("namespaces")
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -79,7 +79,7 @@ func GetLatestGitPull() error {
 }
 
 func Redacted(w io.Writer, output string) {
-	re := regexp.MustCompile(`(?i)password|secret|token|key|https://hooks\.slack\.com|user|arn|ssh-rsa|clientid`)
+	re := regexp.MustCompile(`(?i)password|secret|token|key|https://hooks\.slack\.com`)
 	scanner := bufio.NewScanner(strings.NewReader(output))
 
 	for scanner.Scan() {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -79,7 +79,7 @@ func GetLatestGitPull() error {
 }
 
 func Redacted(w io.Writer, output string) {
-	re := regexp.MustCompile(`(?i)(password|secret|token|key|https://hooks\.slack\.com)`)
+	re := regexp.MustCompile(`(?i)(^.*password.*$|^.*secret.*$|^.*token.*$|^.*key.*$|^.*https://hooks\.slack\.com.*$)`)
 	scanner := bufio.NewScanner(strings.NewReader(output))
 
 	for scanner.Scan() {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -79,7 +79,7 @@ func GetLatestGitPull() error {
 }
 
 func Redacted(w io.Writer, output string) {
-	re := regexp.MustCompile(`(?i)password|secret|token|key|https://hooks\.slack\.com`)
+	re := regexp.MustCompile(`(?i)(^password|^secret|^token|^key|^https://hooks\.slack\.com)`)
 	scanner := bufio.NewScanner(strings.NewReader(output))
 
 	for scanner.Scan() {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
-	"regexp"
 	"strings"
 	"time"
+
+	"github.com/dlclark/regexp2"
 )
 
 type Repository struct {
@@ -79,11 +80,12 @@ func GetLatestGitPull() error {
 }
 
 func Redacted(w io.Writer, output string) {
-	re := regexp.MustCompile(`(?i)(^.*password.*$|^.*secret.*$|^.*token.*$|^.*key.*$|^.*https://hooks\.slack\.com.*$)`)
+	re := regexp2.MustCompile(`(?i)(^.*password.*$|^.*token.*$|^.*key.*$|^.*https://hooks\.slack\.com.*$|(?<!kubernetes_)secret)`, 0)
 	scanner := bufio.NewScanner(strings.NewReader(output))
 
 	for scanner.Scan() {
-		if re.Match([]byte(scanner.Text())) {
+		got, err := re.FindStringMatch(scanner.Text())
+		if got != nil && err == nil {
 			fmt.Fprintln(w, "REDACTED")
 		} else {
 			fmt.Fprintln(w, scanner.Text())

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -79,7 +79,7 @@ func GetLatestGitPull() error {
 }
 
 func Redacted(w io.Writer, output string) {
-	re := regexp.MustCompile(`(?i)(^password|^secret|^token|^key|^https://hooks\.slack\.com)`)
+	re := regexp.MustCompile(`(?i)(password|secret|token|key|https://hooks\.slack\.com)`)
 	scanner := bufio.NewScanner(strings.NewReader(output))
 
 	for scanner.Scan() {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -153,6 +153,27 @@ func TestRedacted(t *testing.T) {
 			expect: "REDACTED\n",
 		},
 		{
+			name: "Redacted secret Content",
+			args: args{
+				output: "secret should be redacted",
+			},
+			expect: "REDACTED\n",
+		},
+		{
+			name: "Redacted secret Content",
+			args: args{
+				output: "this_secret should be redacted",
+			},
+			expect: "REDACTED\n",
+		},
+		{
+			name: "Unredacted kubernetes_secret Content",
+			args: args{
+				output: "This kubernetes_secret should not be redacted",
+			},
+			expect: "This kubernetes_secret should not be redacted\n",
+		},
+		{
 			name: "Unredacted Content",
 			args: args{
 				output: "This test should not be redacted",

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -120,14 +120,14 @@ func TestRedacted(t *testing.T) {
 		{
 			name: "Redacted Password Content",
 			args: args{
-				output: "password: 1234567890",
+				output: "PASSWORD: 1234567890",
 			},
 			expect: "REDACTED\n",
 		},
 		{
 			name: "Redacted Sercet Content",
 			args: args{
-				output: "secret: 1234567890",
+				output: "AWS_SECRET_ACCSS_KEY: 1234567890",
 			},
 			expect: "REDACTED\n",
 		},

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -134,14 +134,14 @@ func TestRedacted(t *testing.T) {
 		{
 			name: "Redacted Token Content",
 			args: args{
-				output: "token: 1234567890",
+				output: "this_token: 1234567890",
 			},
 			expect: "REDACTED\n",
 		},
 		{
 			name: "Redacted Key Content",
 			args: args{
-				output: "key: 1234567890",
+				output: "key_after: 1234567890",
 			},
 			expect: "REDACTED\n",
 		},


### PR DESCRIPTION
This PR 
 - ignore matching strings containing `|user|arn|ssh-rsa|clientid` and also ignores kubernetes_secret.
 - Check for yaml files before doing kubectl on a namespace
