### PR TITLE
Update kubectl --dry-run to kubectl --dry-run=client

### DIFF
--- a/doc/cloud-platform_environment.md
+++ b/doc/cloud-platform_environment.md
@@ -22,7 +22,7 @@ Cloud Platform Environment actions
 * [cloud-platform environment create](cloud-platform_environment_create.md)	 - Create an environment
 * [cloud-platform environment divergence](cloud-platform_environment_divergence.md)	 - Check for divergence between the environments repository and the cluster
 * [cloud-platform environment ecr](cloud-platform_environment_ecr.md)	 - Add an ECR to a namespace
-* [cloud-platform environment plan](cloud-platform_environment_plan.md)	 - Perform a terraform plan and kubectl apply -dry-run for a given namespace using either -namespace flag or the
+* [cloud-platform environment plan](cloud-platform_environment_plan.md)	 - Perform a terraform plan and kubectl apply --dry-run=client for a given namespace using either -namespace flag or the
 	the namespace in the given PR Id/Number
 * [cloud-platform environment prototype](cloud-platform_environment_prototype.md)	 - Create a gov.uk prototype kit site on the cloud platform
 * [cloud-platform environment rds](cloud-platform_environment_rds.md)	 - Add an RDS instance to a namespace

--- a/doc/cloud-platform_environment_plan.md
+++ b/doc/cloud-platform_environment_plan.md
@@ -1,12 +1,12 @@
 ## cloud-platform environment plan
 
-Perform a terraform plan and kubectl apply -dry-run for a given namespace using either -namespace flag or the
+Perform a terraform plan and kubectl apply --dry-run=client for a given namespace using either -namespace flag or the
 	the namespace in the given PR Id/Number
 
 ### Synopsis
 
 
-	Perform a kubectl apply -dry-run and a terraform plan for a given namespace using either -namespace flag or the
+	Perform a kubectl apply --dry-run=client and a terraform plan for a given namespace using either -namespace flag or the
 	the namespace in the given PR Id/Number
 
 	Along with the mandatory input flag, the below environments variables needs to be set

--- a/pkg/commands/environment.go
+++ b/pkg/commands/environment.go
@@ -114,10 +114,10 @@ var environmentEcrCmd = &cobra.Command{
 
 var environmentPlanCmd = &cobra.Command{
 	Use: "plan",
-	Short: `Perform a terraform plan and kubectl apply -dry-run for a given namespace using either -namespace flag or the
+	Short: `Perform a terraform plan and kubectl apply --dry-run=client for a given namespace using either -namespace flag or the
 	the namespace in the given PR Id/Number`,
 	Long: `
-	Perform a kubectl apply -dry-run and a terraform plan for a given namespace using either -namespace flag or the
+	Perform a kubectl apply --dry-run=client and a terraform plan for a given namespace using either -namespace flag or the
 	the namespace in the given PR Id/Number
 
 	Along with the mandatory input flag, the below environments variables needs to be set

--- a/pkg/environment/applier.go
+++ b/pkg/environment/applier.go
@@ -165,7 +165,7 @@ func (m *ApplierImpl) TerraformDestroy(directory string) error {
 func (m *ApplierImpl) KubectlApply(namespace, directory string, dryRun bool) (string, error) {
 	var args []string
 	if dryRun {
-		args = []string{"kubectl", "-n", namespace, "apply", "--dry-run", "-f", directory}
+		args = []string{"kubectl", "-n", namespace, "apply", "--dry-run=client", "-f", directory}
 	} else {
 		args = []string{"kubectl", "-n", namespace, "apply", "-f", directory}
 	}

--- a/pkg/environment/environmentApply.go
+++ b/pkg/environment/environmentApply.go
@@ -70,8 +70,8 @@ func (a *Apply) Initialize() {
 
 // Plan is the entry point for performing a namespace plan.
 // It checks if the working directory is in cloud-platform-environments, checks if a PR number or a namespace is given
-// If a namespace is given, it perform a kubectl apply -dry-run and a terraform init and plan of that namespace
-// else checks for PR number and get the list of changed namespaces in the PR. Then does the kubectl apply -dry-run and
+// If a namespace is given, it perform a `kubectl apply --dry-run=client` and a terraform init and plan of that namespace
+// else checks for PR number and get the list of changed namespaces in the PR. Then does the `kubectl apply --dry-run=client` and
 // terraform init and plan of all the namespaces changed in the PR
 func (a *Apply) Plan() error {
 


### PR DESCRIPTION
`--dry-run` was deprecated without a value in [kubectl 1.18](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.18.md#feature-9), so this adds the `client` value. `client` just prints the object locally.

>You can use the --dry-run=client flag to preview the object that would be sent to your cluster, without really submitting it.