### PR TITLE
Add RedactedEnv function to utils package

### DIFF
--- a/pkg/commands/environment.go
+++ b/pkg/commands/environment.go
@@ -61,7 +61,7 @@ func addEnvironmentCmd(topLevel *cobra.Command) {
 	environmentApplyCmd.Flags().StringVar(&optFlags.GithubToken, "github-token", os.Getenv("TF_VAR_github_token"), "Personal access Token from Github ")
 	environmentApplyCmd.Flags().StringVar(&optFlags.KubecfgPath, "kubecfg", filepath.Join(homedir.HomeDir(), ".kube", "config"), "path to kubeconfig file")
 	environmentApplyCmd.Flags().StringVar(&optFlags.ClusterCtx, "cluster", "", "folder name under namespaces/ inside cloud-platform-environments repo refering to full cluster name")
-	environmentApplyCmd.PersistentFlags().BoolVar(&optFlags.Redacted, "redact", true, "Redact the terraform output before printing")
+	environmentApplyCmd.PersistentFlags().BoolVar(&optFlags.RedactedEnv, "redact", true, "Redact the terraform output before printing")
 
 	// e.g. if this is the Pull rquest to perform the apply: https://github.com/ministryofjustice/cloud-platform-environments/pull/8370, the pr ID is 8370.
 	environmentPlanCmd.Flags().IntVar(&optFlags.PRNumber, "prNumber", 0, "Pull request ID or number to which you want to perform the plan")
@@ -71,7 +71,7 @@ func addEnvironmentCmd(topLevel *cobra.Command) {
 	environmentPlanCmd.Flags().StringVar(&optFlags.GithubToken, "github-token", os.Getenv("TF_VAR_github_token"), "Personal access Token from Github ")
 	environmentPlanCmd.Flags().StringVar(&optFlags.KubecfgPath, "kubecfg", filepath.Join(homedir.HomeDir(), ".kube", "config"), "path to kubeconfig file")
 	environmentPlanCmd.Flags().StringVar(&optFlags.ClusterCtx, "cluster", "", "folder name under namespaces/ inside cloud-platform-environments repo refering to full cluster name")
-	environmentPlanCmd.PersistentFlags().BoolVar(&optFlags.Redacted, "redact", true, "Redact the terraform output before printing")
+	environmentPlanCmd.PersistentFlags().BoolVar(&optFlags.RedactedEnv, "redact", true, "Redact the terraform output before printing")
 
 	environmentBumpModuleCmd.Flags().StringVarP(&module, "module", "m", "", "Module to upgrade the version")
 	environmentBumpModuleCmd.Flags().StringVarP(&moduleVersion, "module-version", "v", "", "Semantic version to bump a module to")

--- a/pkg/environment/environmentApply.go
+++ b/pkg/environment/environmentApply.go
@@ -17,7 +17,7 @@ type Options struct {
 	Namespace, KubecfgPath, ClusterCtx, GithubToken string
 	PRNumber                                        int
 	AllNamespaces                                   bool
-	EnableApplySkip, Redacted                       bool
+	EnableApplySkip, RedactedEnv                    bool
 }
 
 // RequiredEnvVars is used to store values such as TF_VAR_ , github and pingdom tokens
@@ -282,7 +282,7 @@ func (a *Apply) planNamespace() error {
 		}
 
 		fmt.Println("\nOutput of terraform:")
-		util.Redacted(os.Stdout, outputTerraform, a.Options.Redacted)
+		util.RedactedEnv(os.Stdout, outputTerraform, a.Options.RedactedEnv)
 	} else {
 		fmt.Printf("Namespace %s does not have terraform resources folder, skipping terraform plan\n", a.Options.Namespace)
 	}
@@ -366,7 +366,7 @@ func (a *Apply) applyNamespace() error {
 		}
 
 		fmt.Println("\nOutput of terraform:")
-		util.Redacted(os.Stdout, outputTerraform, a.Options.Redacted)
+		util.RedactedEnv(os.Stdout, outputTerraform, a.Options.RedactedEnv)
 	} else {
 		fmt.Printf("Namespace %s does not have terraform resources folder, skipping terraform apply", a.Options.Namespace)
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -98,6 +98,25 @@ func Redacted(w io.Writer, output string, redact bool) {
 	}
 }
 
+// RedactedEnv read bytes of data for environment pipeline sensitive strings and prints REDACTED
+func RedactedEnv(w io.Writer, output string, redact bool) {
+	re := regexp2.MustCompile(`(?i).*hex.*= .*`, 0)
+	scanner := bufio.NewScanner(strings.NewReader(output))
+
+	for scanner.Scan() {
+		if redact {
+			got, err := re.FindStringMatch(scanner.Text())
+			if got != nil && err == nil {
+				fmt.Fprintln(w, "REDACTED")
+			} else {
+				fmt.Fprintln(w, scanner.Text())
+			}
+		} else {
+			fmt.Fprintln(w, scanner.Text())
+		}
+	}
+}
+
 func GetDatePastMinute(timestamp string, minutes int) (*Date, error) {
 	d := &Date{}
 	curTime, err := time.Parse("2006-01-02T15:04:05Z07:00", timestamp)

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -204,7 +204,7 @@ func TestRedactedEnv(t *testing.T) {
 		{
 			name: "Redacted random_id hex Content",
 			args: args{
-				output: `- hex = "52e372f2fd8b4bc489b5ccb87311efb0fb9b048796195dfb3cf0aafadf7f0dac`,
+				output: `- hex = "abcdefg123456"`,
 			},
 			expect: "REDACTED\n",
 		},

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -192,6 +192,33 @@ func TestRedacted(t *testing.T) {
 	}
 }
 
+func TestRedactedEnv(t *testing.T) {
+	type args struct {
+		output string
+	}
+	tests := []struct {
+		name   string
+		args   args
+		expect string
+	}{
+		{
+			name: "Redacted random_id hex Content",
+			args: args{
+				output: `- hex = "52e372f2fd8b4bc489b5ccb87311efb0fb9b048796195dfb3cf0aafadf7f0dac`,
+			},
+			expect: "REDACTED\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			RedactedEnv(&output, tt.args.output, true)
+			if tt.expect != output.String() {
+				t.Errorf("got %s but expected %s", output.String(), tt.expect)
+			}
+		})
+	}
+}
 func TestGetDatePastMinute(t *testing.T) {
 	type args struct {
 		timestamp string

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -208,6 +208,13 @@ func TestRedactedEnv(t *testing.T) {
 			},
 			expect: "REDACTED\n",
 		},
+		{
+			name: "Unredacted Content",
+			args: args{
+				output: "This test output should not be redacted",
+			},
+			expect: "This test output should not be redacted\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR adds a RedactedEnv function to `util` package for relaxing terraform environment command output to redact only `hex` values.