### PR TITLE
Skip namespace deletion PRs for terraform plan

### DIFF
--- a/pkg/environment/environmentApply.go
+++ b/pkg/environment/environmentApply.go
@@ -100,8 +100,10 @@ func (a *Apply) Plan() error {
 		if err != nil {
 			return fmt.Errorf("failed to fetch list of changed files: %s in PR %v", err, a.Options.PRNumber)
 		}
+
 		changedNamespaces, err := nsChangedInPR(files, a.Options.ClusterDir, false)
 		if err != nil {
+			fmt.Println("failed to get list of changed namespaces in PR:", err)
 			return err
 		}
 		for _, namespace := range changedNamespaces {

--- a/pkg/util/filesystem.go
+++ b/pkg/util/filesystem.go
@@ -4,7 +4,6 @@ package util
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 )
@@ -108,7 +107,7 @@ func IsFilePathExists(filePath string) (bool, error) {
 func IsYamlFileExists(path string) bool {
 	files, err := os.ReadDir(path)
 	if err != nil {
-		log.Fatal(err)
+		return false
 	}
 
 	for _, file := range files {


### PR DESCRIPTION
Do soft return with false if yaml file doesnot exists. For PRs which has namespace deletion, we dont need to error if the yaml file doesnot exists.