### PR TITLE
feat: 🎸 add pipeline & pipeline delete-cluster command

### DIFF
--- a/doc/cloud-platform.md
+++ b/doc/cloud-platform.md
@@ -21,6 +21,7 @@ cloud-platform [flags]
 * [cloud-platform duplicate](cloud-platform_duplicate.md)	 - Cloud Platform duplicate resource
 * [cloud-platform environment](cloud-platform_environment.md)	 - Cloud Platform Environment actions
 * [cloud-platform kubecfg](cloud-platform_kubecfg.md)	 - Cloud Platform kubeconfig related commands
+* [cloud-platform pipeline](cloud-platform_pipeline.md)	 - Cloud Platform pipeline actions
 * [cloud-platform prototype](cloud-platform_prototype.md)	 - Cloud Platform Prototype actions
 * [cloud-platform terraform](cloud-platform_terraform.md)	 - Terraform actions.
 

--- a/doc/cloud-platform_pipeline.md
+++ b/doc/cloud-platform_pipeline.md
@@ -1,0 +1,21 @@
+## cloud-platform pipeline
+
+Cloud Platform pipeline actions
+
+### Options
+
+```
+  -h, --help   help for pipeline
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform](cloud-platform.md)	 - Multi-purpose CLI from the Cloud Platform team
+* [cloud-platform pipeline delete-cluster](cloud-platform_pipeline_delete-cluster.md)	 - delete a cloud-platform cluster via the pipeline
+

--- a/doc/cloud-platform_pipeline_delete-cluster.md
+++ b/doc/cloud-platform_pipeline_delete-cluster.md
@@ -1,0 +1,40 @@
+## cloud-platform pipeline delete-cluster
+
+delete a cloud-platform cluster via the pipeline
+
+### Synopsis
+
+
+Running this command will delete an existing eks cluster in the cloud-platform aws account.
+It will delete the components, then the cluster, the VPC, terraform workspace and cleanup the cloudwatch log group.
+
+   The delete will run remotely in the pipeline
+
+You must have the following environment variables set, or passed via arguments:
+	- a cluster name
+
+   ** You _must_ have the fly cli installed **
+   --> https://concourse-ci.org/fly.html
+
+
+```
+cloud-platform pipeline delete-cluster [flags]
+```
+
+### Options
+
+```
+      --cluster-name string   cluster to delete
+  -h, --help                  help for delete-cluster
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform pipeline](cloud-platform_pipeline.md)	 - Cloud Platform pipeline actions
+

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -14,4 +14,5 @@ func AddCommands(topLevel *cobra.Command) {
 	addDecodeSecret(topLevel)
 	addDuplicateCmd(topLevel)
 	addClusterCmd(topLevel)
+	addPipelineCmd(topLevel)
 }

--- a/pkg/commands/pipeline.go
+++ b/pkg/commands/pipeline.go
@@ -1,0 +1,71 @@
+package commands
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	"github.com/ministryofjustice/cloud-platform-cli/pkg/pipeline"
+	util "github.com/ministryofjustice/cloud-platform-cli/pkg/util"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type pipelineOptions struct {
+	util.Options
+	Name          string
+	MaxNameLength int8
+}
+
+var cliOpt pipelineOptions
+
+func (opt *pipelineOptions) addPipelineDeleteClusterFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&cliOpt.Name, "cluster-name", "", "cluster to delete")
+}
+
+func addPipelineDeleteClusterCmd(toplevel *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "delete-cluster",
+		Short: `delete a cloud-platform cluster via the pipeline`,
+		Long: heredoc.Doc(`
+
+			Running this command will delete an existing eks cluster in the cloud-platform aws account.
+			It will delete the components, then the cluster, the VPC, terraform workspace and cleanup the cloudwatch log group.
+
+      The delete will run remotely in the pipeline
+
+			You must have the following environment variables set, or passed via arguments:
+				- a cluster name
+
+      ** You _must_ have the fly cli installed **
+      --> https://concourse-ci.org/fly.html
+`),
+		PreRun: upgradeIfNotLatest,
+		Run: func(cmd *cobra.Command, args []string) {
+			contextLogger := log.WithFields(log.Fields{"subcommand": "delete-cluster"})
+			cliOpt.MaxNameLength = 12
+
+			if cliOpt.Name == "" {
+				contextLogger.Fatal("--cluster-name is required")
+			}
+
+			if err := cliOpt.IsNameValid(); err != nil {
+				contextLogger.Fatal(err)
+			}
+
+			pipeline.DeletePipelineShellCmds(cliOpt.Name)
+		},
+	}
+
+	cliOpt.addPipelineDeleteClusterFlags(cmd)
+	toplevel.AddCommand(cmd)
+}
+
+func addPipelineCmd(topLevel *cobra.Command) {
+	topLevel.AddCommand(pipelineCmd)
+
+	addPipelineDeleteClusterCmd(pipelineCmd)
+}
+
+var pipelineCmd = &cobra.Command{
+	Use:    "pipeline",
+	Short:  `Cloud Platform pipeline actions`,
+	PreRun: upgradeIfNotLatest,
+}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -1,0 +1,27 @@
+package pipeline
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func runCmd(cliCmd string, args []string) {
+	cmd := exec.Command(cliCmd, args...)
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println("could not run command: ", err)
+	}
+}
+
+func DeletePipelineShellCmds(clusterName string) {
+	runCmd("fly", []string{"--target", "manager", "login", "--team-name", "main", "--concourse-url", "https://concourse.cloud-platform.service.justice.gov.uk/"})
+	runCmd("bash", []string{"-c", "wget -qO- https://raw.githubusercontent.com/ministryofjustice/cloud-platform-terraform-concourse/main/pipelines/manager/main/delete-cluster.yaml | fly --target manager set-pipeline -p delete-cluster -c - -v cluster_name=" + clusterName})
+	runCmd("fly", []string{"--target", "manager", "trigger-job", "-j", "delete-cluster/delete"})
+	fmt.Println("Deleting... https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/delete-cluster/jobs/delete/builds/latest")
+}

--- a/pkg/util/clusterName.go
+++ b/pkg/util/clusterName.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"errors"
+	"strings"
+)
+
+type ClusterName interface {
+	IsNameValid(date, minHour string)
+}
+
+type Options struct {
+	Name          string
+	MaxNameLength int
+}
+
+func (opt *Options) IsNameValid() error {
+	if len(opt.Name) > opt.MaxNameLength {
+		return errors.New("cluster name is too long, please use a shorter name")
+	}
+
+	if strings.Contains(opt.Name, "live") || strings.Contains(opt.Name, "manager") {
+		return errors.New("cluster name cannot contain the words 'live' or 'manager'")
+	}
+	return nil
+}

--- a/pkg/util/clusterName_test.go
+++ b/pkg/util/clusterName_test.go
@@ -1,0 +1,60 @@
+package util
+
+import "testing"
+
+func TestOptions_IsNameValid(t *testing.T) {
+	type fields struct {
+		Name          string
+		MaxNameLength int
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			"GIVEN a cluster name that is longer than the mx length THEN return an error",
+			fields{
+				"long-cluster-name",
+				3,
+			},
+			true,
+		},
+		{
+			"GIVEN a cluster name that includes 'live' THEN return an error",
+			fields{
+				"cluster-live-name",
+				50,
+			},
+			true,
+		},
+		{
+			"GIVEN a cluster name that includes 'manager' THEN return an error",
+			fields{
+				"cluster-manager-name",
+				50,
+			},
+			true,
+		},
+		{
+			"GIVEN a cluster name that is valid THEN return nil",
+			fields{
+				"cluster-valid-name",
+				50,
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := &Options{
+				Name:          tt.fields.Name,
+				MaxNameLength: tt.fields.MaxNameLength,
+			}
+			if err := opt.IsNameValid(); (err != nil) != tt.wantErr {
+				t.Errorf("Options.IsNameValid() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/testdata/help.ct
+++ b/testdata/help.ct
@@ -13,6 +13,7 @@ Available Commands:
   environment   Cloud Platform Environment actions
   help          Help about any command
   kubecfg       Cloud Platform kubeconfig related commands
+  pipeline      Cloud Platform pipeline actions
   prototype     Cloud Platform Prototype actions
   terraform     Terraform actions.
 


### PR DESCRIPTION
Using one command you can delete a cluster via the pipeline

`cloud-platform pipeline delete-cluster --cluster-name <name>`

The pipeline can delete 5 clusters simultaneously

Future PRs:

- post failures to `lower-priority-alarms`
- automate deleting clusters at the end of the week (list and then delete) (another job within the pipeline maybe?)