### PR TITLE
Ignore kubectl dependency bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,19 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "k8s.io/kubectl"
+        versions:
+          - ">=v0.26.0"
+      - dependency-name: "k8s.io/client-go"
+        versions:
+          - ">=v0.26.0"
+      - dependency-name: "k8s.io/api"
+        versions:
+          - ">=v0.26.0"
+      - dependency-name: "k8s.io/apimachinery"
+        versions:
+          - ">=v0.26.0"
     groups:
       go:
         patterns:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.20.5-alpine AS cli_builder
 ENV \
     CGO_ENABLED=0 \
     GOOS=linux \
-    KUBECTL_VERSION=1.22.15 \
+    KUBECTL_VERSION=1.24.15 \
     CLOUD_PLATFORM_CLI_VERSION=DOCKER \
     TERRAFORM_VERSION=1.2.5
 


### PR DESCRIPTION
- The cluster is in k8s 1.24 and hence as per skew policy we cant go beyond 1.25. As it is tricky to downgrade the kubectl library, pin the version to the 0.26 and not upgrade. The 0.26 library will have less breaking things to work with 1.24 cluster than a 0.29 version (latest). Update the pinned dependencies when the cluster is upgraded.
- Update dockerfile to match the current cluster version