### PR TITLE
chore: 🤖 upgrade go version 1.19 -> 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ministryofjustice/cloud-platform-cli
 
-go 1.19
+go 1.21
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0


### PR DESCRIPTION
Our dockerfile is set to go 1.21, there is no reason to stay on go.19