### PR TITLE
Add batch-apply option to environment apply 

### DIFF
--- a/pkg/commands/environment.go
+++ b/pkg/commands/environment.go
@@ -55,6 +55,8 @@ func addEnvironmentCmd(topLevel *cobra.Command) {
 
 	// flags
 	environmentApplyCmd.Flags().BoolVar(&optFlags.AllNamespaces, "all-namespaces", false, "Apply all namespaces with -all-namespaces")
+	environmentApplyCmd.Flags().IntVar(&optFlags.BatchApplyIndex, "batch-apply-index", 0, "Starting index for Apply to a batch of namespaces")
+	environmentApplyCmd.Flags().IntVar(&optFlags.BatchApplySize, "batch-apply-size", 10, "Number of namespaces to apply in a batch")
 	environmentApplyCmd.Flags().BoolVar(&optFlags.EnableApplySkip, "enable-apply-skip", false, "Enable skipping apply for a namespace")
 	environmentApplyCmd.Flags().StringVarP(&optFlags.Namespace, "namespace", "n", "", "Namespace which you want to perform the apply")
 	environmentApplyCmd.Flags().IntVar(&optFlags.PRNumber, "prNumber", 0, "Pull request ID or number to which you want to perform the apply")
@@ -218,6 +220,11 @@ var environmentApplyCmd = &cobra.Command{
 
 		if optFlags.AllNamespaces {
 			err := applier.ApplyAll()
+			if err != nil {
+				contextLogger.Fatal(err)
+			}
+		} else if optFlags.BatchApplyIndex > 0 && optFlags.BatchApplySize > 0 {
+			err := applier.ApplyBatch()
 			if err != nil {
 				contextLogger.Fatal(err)
 			}

--- a/pkg/environment/common.go
+++ b/pkg/environment/common.go
@@ -12,7 +12,6 @@ const (
 	liveBaseDir          = "namespaces/live.cloud-platform.service.justice.gov.uk"
 	betaBaseDir          = "namespaces/live-2.cloud-platform.service.justice.gov.uk"
 	envTemplateLocation  = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/main/namespace-resources-cli-template"
-	numRoutines          = 1
 	mojOwner             = "ministryofjustice"
 )
 

--- a/pkg/util/filesystem.go
+++ b/pkg/util/filesystem.go
@@ -3,12 +3,11 @@ package util
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 )
 
-func GetFolderChunks(repoPath string, numRoutines int) ([][]string, error) {
+func GetFolderChunks(repoPath string, batchIndex int, batchSize int) ([]string, error) {
 	folders, err := ListFolderPaths(repoPath)
 	if err != nil {
 		return nil, err
@@ -19,11 +18,10 @@ func GetFolderChunks(repoPath string, numRoutines int) ([][]string, error) {
 	var nsFolders []string
 	nsFolders = append(nsFolders, folders[1:]...)
 
-	folderChunks, err := chunkFolders(nsFolders, numRoutines)
-	if err != nil {
-		return nil, err
+	if batchIndex < 0 || batchSize <= 0 || batchIndex+batchSize > len(nsFolders) {
+		return nil, errors.New("invalid index or size")
 	}
-	return folderChunks, nil
+	return nsFolders[batchIndex : batchIndex+batchSize], nil
 }
 
 // ListFolders take the path as input, list all the folders in the give path and
@@ -51,27 +49,6 @@ func ListFolderPaths(path string) ([]string, error) {
 	}
 
 	return folders, nil
-}
-
-func chunkFolders(folders []string, nRoutines int) ([][]string, error) {
-	nChunks := len(folders) / nRoutines
-
-	fmt.Println("Number of folders per chunk", nChunks)
-
-	var folderChunks [][]string
-	for {
-		if len(folders) == 0 {
-			break
-		}
-
-		if len(folders) < nChunks {
-			nChunks = len(folders)
-		}
-
-		folderChunks = append(folderChunks, folders[0:nChunks])
-		folders = folders[nChunks:]
-	}
-	return folderChunks, nil
 }
 
 func ListFiles(path string) ([]string, error) {

--- a/pkg/util/filesystem_test.go
+++ b/pkg/util/filesystem_test.go
@@ -3,6 +3,7 @@ package util_test
 import (
 	"log"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/ministryofjustice/cloud-platform-cli/pkg/util"
@@ -80,4 +81,36 @@ func TestIsYamlFileExists(t *testing.T) {
 		t.Errorf("Expected file %v not found", tempFile)
 	}
 	defer os.RemoveAll("namespaces")
+}
+
+func TestGetFolderChunks(t *testing.T) {
+	createTestFolderStructure(t)
+
+	defer os.RemoveAll("namespaces")
+
+	nsfolders, err := util.GetFolderChunks("namespaces", 3, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nsfolders) != 3 {
+		t.Errorf("Expected 3 folders got %v", len(nsfolders))
+	}
+
+}
+func createTestFolderStructure(t *testing.T) {
+	// loop and create folders
+	for i := 0; i < 10; i++ {
+		tempDir := "namespaces/testCluster/testNamespace" + strconv.Itoa(i)
+		tempFile := tempDir + "/foo.yaml"
+
+		if err := os.MkdirAll(tempDir, os.ModePerm); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := os.Create(tempFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
 }


### PR DESCRIPTION
This PR add option to apply set of namespaces based on --batch-apply-index and --batch-apply-size. This is in preparation to split the apply-live environment job and apply in batches parallelly