### PR TITLE
chore: 🤖 remove alpine in favour of debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Cloud Platform tools (CLI)
-FROM golang:1.21.6-alpine AS cli_builder
+FROM golang:1.21.7-bookworm AS cli_builder
 
 ENV \
   CGO_ENABLED=0 \
@@ -10,13 +10,14 @@ ENV \
 
 WORKDIR /build
 
+RUN apt update
+
 RUN \
-  apk add \
-  --no-cache \
-  --no-progress \
-  --update \
+  apt \
+  install \
   curl \
-  unzip
+  unzip \
+  -y
 
 # Build cli
 COPY go.mod .
@@ -36,48 +37,28 @@ RUN chmod +x kubectl terraform
 
 # ---
 
-FROM alpine:3.19.0
+FROM debian:bookworm-20240211-slim
 
 ENV AWSCLI_VERSION=2.7.6
-ENV GLIBC_VER=2.31-r0
 
-RUN apk add --update --no-cache \
+RUN apt update
+
+RUN apt install \
+  unzip \
   groff \
-  bash \
   ca-certificates \
-  coreutils \
-  findutils \
+  curl \
   git-crypt \
   git \
-  gnupg \
   grep \
   openssl \
   parallel \
-  python3 
+  python3  \
+  -y
 
-
-# AWS cli installation taken from https://github.com/aws/aws-cli/issues/4685#issuecomment-941927371
-RUN apk add --no-cache --virtual .dependencies binutils curl \
-  && curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
-  && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk \
-  && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk \
-  && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-i18n-${GLIBC_VER}.apk \
-  && apk add --force-overwrite --no-cache --virtual .glibc \
-  glibc-${GLIBC_VER}.apk \
-  glibc-bin-${GLIBC_VER}.apk \
-  glibc-i18n-${GLIBC_VER}.apk \
-  && /usr/glibc-compat/bin/localedef -i en_US -f UTF-8 en_US.UTF-8 \
-  && curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip -o awscliv2.zip \
-  && unzip awscliv2.zip \
-  && aws/install \
-  && rm -rf \
-  awscliv2.zip \
-  aws \
-  /usr/local/aws-cli/v2/*/dist/aws_completer \
-  /usr/local/aws-cli/v2/*/dist/awscli/data/ac.index \
-  /usr/local/aws-cli/v2/*/dist/awscli/examples \
-  glibc-*.apk \
-  && apk del --purge .dependencies
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip
+RUN ./aws/install
 
 COPY --from=cli_builder /build/cloud-platform /usr/local/bin/cloud-platform
 COPY --from=cli_builder /build/kubectl /usr/local/bin/kubectl

--- a/docker-test.yaml
+++ b/docker-test.yaml
@@ -19,3 +19,7 @@ commandTests:
     command: "cloud-platform"
     args: ["version", "--skip-version-check"]
     exitCode: 0
+  - name: "aws cli good command"
+    command: "aws"
+    args: ["--version"]
+    exitCode: 0


### PR DESCRIPTION
Debian is bigger but it'll be cached by concourse but is a lot easier to work with and avoids the random DNS breakages associated with alpine

```
debian                                                    bookworm-20240211-slim  97.1MB 
alpine                                                     3.19                                       7.73MB
```