### PR TITLE
Add support for building adhoc images from git refs

### DIFF
--- a/.github/workflows/build-adhoc-release.yml
+++ b/.github/workflows/build-adhoc-release.yml
@@ -12,33 +12,6 @@ permissions:
   contents: write
 
 jobs:
-  build:
-    name: GoReleaser build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.events.inputs.build_branch }}
-          fetch-depth: 0 # See: https://goreleaser.com/ci/actions/
-      - name: Fetch all tags
-        run: git fetch --force --tags
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: " 1.21.x"
-        id: go
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
-        with:
-          version: latest
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
-
   docker:
     name: Build container and push to DockerHub
     runs-on: ubuntu-latest

--- a/.github/workflows/build-adhoc-release.yml
+++ b/.github/workflows/build-adhoc-release.yml
@@ -1,0 +1,76 @@
+name: Build and push a new adhoc release
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_branch:
+        description: "Branch to build from"
+        required: true
+        default: "main"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: GoReleaser build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.events.inputs.build_branch }}
+          fetch-depth: 0 # See: https://goreleaser.com/ci/actions/
+      - name: Fetch all tags
+        run: git fetch --force --tags
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: " 1.21.x"
+        id: go
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+  docker:
+    name: Build container and push to DockerHub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.events.inputs.build_branch }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # - name: Get Tags for Image
+      #   id: metadata
+      #   uses: docker/metadata-action@v5
+      #   with:
+      #     images: ministryofjustice/cloud-platform-cli
+      #     tags: |
+      #       type=ref,event=tag
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ github.events.inputs.build_branch }}
+          build-args: CLOUD_PLATFORM_CLI_VERSION=${{ github.events.inputs.build_branch }}


### PR DESCRIPTION
In order to proceed with the split components infrastructure work we need the ability to create a new cloud-platform-cli image seperate to the production version so we can test our cluster builds.

Ref https://github.com/ministryofjustice/cloud-platform/issues/5365

What this PR does is add a new github action which takes `branch` as an option when you manually run the action. It will then build the image based off that branch/ref and tag a new image with it. This way we don't break the production release of the cli.