### PR TITLE
perf: ⚡️ call GetAllNodes once

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -62,7 +62,7 @@ func NewCluster(c *client.KubeClient) (*Cluster, error) {
 		return nil, err
 	}
 
-	oldestNode, err := getOldestNode(c)
+	oldestNode, err := oldestNode(nodes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cluster/node.go
+++ b/pkg/cluster/node.go
@@ -90,7 +90,6 @@ func GetAllNodes(c *client.KubeClient) ([]v1.Node, error) {
 	return n, nil
 }
 
-// getOldestNode returns the oldest node in a cluster
 func getOldestNode(c *client.KubeClient) (v1.Node, error) {
 	nodes, err := GetAllNodes(c)
 	if err != nil {

--- a/pkg/util/testutils.go
+++ b/pkg/util/testutils.go
@@ -14,7 +14,7 @@ func FileContainsString(t *testing.T, filename string, searchString string) {
 	}
 
 	if !(strings.Contains(string(contents), searchString)) {
-		t.Error(fmt.Sprintf("Didn't find string: %s in file: %s", searchString, filename))
+		t.Errorf(fmt.Sprintf("Didn't find string: %s in file: %s", searchString, filename))
 	}
 }
 

--- a/pkg/util/testutils.go
+++ b/pkg/util/testutils.go
@@ -14,7 +14,7 @@ func FileContainsString(t *testing.T, filename string, searchString string) {
 	}
 
 	if !(strings.Contains(string(contents), searchString)) {
-		t.Errorf(fmt.Sprintf("Didn't find string: %s in file: %s", searchString, filename))
+		t.Error(fmt.Sprintf("Didn't find string: %s in file: %s", searchString, filename))
 	}
 }
 

--- a/pkg/util/testutils.go
+++ b/pkg/util/testutils.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -14,7 +13,7 @@ func FileContainsString(t *testing.T, filename string, searchString string) {
 	}
 
 	if !(strings.Contains(string(contents), searchString)) {
-		t.Errorf(fmt.Sprintf("Didn't find string: %s in file: %s", searchString, filename))
+		t.Errorf("Didn't find string: %s in file: %s", searchString, filename)
 	}
 }
 


### PR DESCRIPTION
We were hitting errors calling the Kube API so quickly with the same request twice

```
time="2024-08-28T13:05:19Z" level=fatal msg="oldest node is tainted with monitoring-node and can't find a new node" subcommand=recycle-node
```

We already have all the nodes, we can pass this directly to the right function