### PR TITLE
refactor: 💡 don't lookup oldest unless neeeded

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -51,7 +51,9 @@ type AwsCredentials struct {
 
 // NewCluster creates a new Cluster object and populates its
 // fields with the values from the Kubernetes cluster in the client passed to it.
-func NewCluster(c *client.KubeClient) (*Cluster, error) {
+func NewCluster(c *client.KubeClient, recycleOldest bool) (*Cluster, error) {
+	oldNode := v1.Node{}
+
 	pods, err := getPods(c)
 	if err != nil {
 		return nil, err
@@ -62,9 +64,13 @@ func NewCluster(c *client.KubeClient) (*Cluster, error) {
 		return nil, err
 	}
 
-	oldestNode, err := oldestNode(nodes)
-	if err != nil {
-		return nil, err
+	if recycleOldest {
+		n, err := oldestNode(nodes)
+		if err != nil {
+			return nil, err
+		}
+
+		oldNode = n
 	}
 
 	newestNode, err := GetNewestNode(c, nodes)
@@ -76,7 +82,7 @@ func NewCluster(c *client.KubeClient) (*Cluster, error) {
 		Name:       nodes[0].Labels["Cluster"],
 		Pods:       pods,
 		Nodes:      nodes,
-		OldestNode: oldestNode,
+		OldestNode: oldNode,
 		NewestNode: newestNode,
 	}, nil
 }
@@ -99,19 +105,4 @@ func NewAwsCreds(region string) (*AwsCredentials, error) {
 		Session: sess,
 		Region:  region,
 	}, nil
-}
-
-// RefreshStatus performs a value overwrite of the cluster status.
-// This is useful for when the cluster is being updated.
-func (c *Cluster) RefreshStatus(client *client.KubeClient) (err error) {
-	c.Nodes, err = GetAllNodes(client)
-	if err != nil {
-		return err
-	}
-
-	c.OldestNode, err = getOldestNode(client)
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/pkg/cluster/node.go
+++ b/pkg/cluster/node.go
@@ -99,7 +99,6 @@ func getOldestNode(c *client.KubeClient) (v1.Node, error) {
 	return oldestNode(nodes)
 }
 
-// oldestNode takes a slice of nodes and returns the oldest node
 func oldestNode(nodes []v1.Node) (v1.Node, error) {
 	oldestNode := nodes[0]
 	for _, node := range nodes {

--- a/pkg/cluster/node.go
+++ b/pkg/cluster/node.go
@@ -90,15 +90,6 @@ func GetAllNodes(c *client.KubeClient) ([]v1.Node, error) {
 	return n, nil
 }
 
-func getOldestNode(c *client.KubeClient) (v1.Node, error) {
-	nodes, err := GetAllNodes(c)
-	if err != nil {
-		return v1.Node{}, err
-	}
-
-	return oldestNode(nodes)
-}
-
 func oldestNode(nodes []v1.Node) (v1.Node, error) {
 	oldestNode := nodes[0]
 	for _, node := range nodes {

--- a/pkg/commands/cluster.go
+++ b/pkg/commands/cluster.go
@@ -525,7 +525,7 @@ var clusterRecycleNodeCmd = &cobra.Command{
 			Options: &opt,
 		}
 
-		recycle.Cluster, err = cloudPlatform.NewCluster(recycle.Client)
+		recycle.Cluster, err = cloudPlatform.NewCluster(recycle.Client, opt.Oldest)
 		if err != nil {
 			contextLogger.Fatal(err)
 		}


### PR DESCRIPTION
I am still hitting the error which is caused when the oldest node is a monitoring node, we only care about that when we are recycling nodes and are specifying we want to recycle the oldest node.

We want to be prevented from recycling the oldest node when it's a monitoring node because we only care about recycling nodes with user workloads on.

When we specify which node to recycle it doesn't matter that the oldest one is a monitoring node because we have explicitly specified which node we will recycle, so we can safely bypass checking and throwing the error when we have named the instance to recycle.

Also, remove aa couple of [unused function 1](https://github.com/search?q=repo%3Aministryofjustice%2Fcloud-platform-cli%20RefreshStatus&type=code), [unused function 2](https://github.com/search?q=repo%3Aministryofjustice%2Fcloud-platform-cli+getOldestNode&type=code)

These changes allow me to use the `cloud-platform cluster recycle-node --name foobar-node` command in the cordon and drain pipeline and avoid irrelevant errors