### PR TITLE
:bug: Fix regex bug in slack validator

### DIFF
--- a/pkg/environment/slackChannelValidator.go
+++ b/pkg/environment/slackChannelValidator.go
@@ -4,6 +4,6 @@ type slackChannelValidator struct{}
 
 func (v *slackChannelValidator) isValid(s string) bool {
 	r := new(regexValidator)
-	r.regex = `^[a-z\-_]+$`
+	r.regex = `^[a-z0-9\-_]+$`
 	return r.isValid(s)
 }

--- a/pkg/environment/slackChannelValidator_test.go
+++ b/pkg/environment/slackChannelValidator_test.go
@@ -1,0 +1,37 @@
+package environment
+
+import "testing"
+
+func TestSlackChannelValidator_IsValid(t *testing.T) {
+	v := &slackChannelValidator{}
+
+	tests := []struct {
+		name string
+		args string
+		want bool
+	}{
+		{
+			name: "valid slack channel",
+			args: "valid-channel",
+			want: true,
+		},
+		{
+			name: "invalid slack channel with special characters",
+			args: "invalid#channel",
+			want: false,
+		},
+		{
+			name: "invalid slack channel with uppercase letters",
+			args: "InvalidChannel",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := v.isValid(tt.args); got != tt.want {
+				t.Errorf("slackChannelValidator.isValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit relates to
https://github.com/ministryofjustice/cloud-platform-cli/issues/604 and
fixes the lack of numbers in the validation regex. The commit also
contains a test table.
