### PR TITLE
:fire: Remove codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Cloud Platform Tool CLI
 
 [![Releases](https://img.shields.io/github/release/ministryofjustice/cloud-platform-cli/all.svg?style=flat-square)](https://github.com/ministryofjustice/cloud-platform-cli/releases)
-[![codecov](https://codecov.io/gh/ministryofjustice/cloud-platform-cli/branch/main/graph/badge.svg?token=BUF45279MY)](https://codecov.io/gh/ministryofjustice/cloud-platform-cli)
 
 `cloud-platform` is a command-line tool used by the cloud-platform team and tenants to perform actions on the platform, for example:
 


### PR DESCRIPTION
It's no longer used, and it's not a good advert to have <50% stamped on the readme (unless we use that as a motivator to improve)