### PR TITLE
fix: 🐛 cross-compatibility between macos and linux sed cmds

### DIFF
--- a/pkg/environment/updateVersion.go
+++ b/pkg/environment/updateVersion.go
@@ -40,7 +40,7 @@ func updateVersion(moduleName, actualDbVersion, terraformDbVersion, tfDir string
 
 	escapedTfDbVersion := "\"" + splitTfDbVersion[0] + "\\." + splitTfDbVersion[1] + "\""
 
-	sedCmd := exec.Command("/bin/sh", "-c", "sed -i '' -e '"+dbMatch[1]+"s/"+escapedTfDbVersion+"/\""+actualDbVersion+"\"/g' "+string(fileName))
+	sedCmd := exec.Command("/bin/sh", "-c", "sed -i'' -e '"+dbMatch[1]+"s/"+escapedTfDbVersion+"/\""+actualDbVersion+"\"/g' "+string(fileName))
 
 	sedCmd.Dir = tfDir
 


### PR DESCRIPTION
- macos and linux sed commands behave differently for in file replace `-i`
- use a cross compatible command