### PR TITLE
📝 Update the update messaging

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -61,7 +61,7 @@ func (r *Release) isLatestVersion() (error, bool) {
 
 func (r *Release) informUserToUpgrade() error {
 	fmt.Printf("Update required. Current version: %s, Latest version: %s\n\n", r.innerStruct.CurrentVersion, r.innerStruct.LatestTag)
-	return fmt.Errorf("To upgrade the Cloud Platform CLI, please refer to the Cloud Platform User Guide https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/cloud-platform-cli.html#keeping-up-to-date")
+	return fmt.Errorf("To update the Cloud Platform CLI, please refer to the Cloud Platform User Guide https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/cloud-platform-cli.html#keeping-up-to-date")
 }
 
 func (r *myRelease) getLatestReleaseInfo() error {

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -61,7 +61,7 @@ func (r *Release) isLatestVersion() (error, bool) {
 
 func (r *Release) informUserToUpgrade() error {
 	fmt.Printf("Update required. Current version: %s, Latest version: %s\n\n", r.innerStruct.CurrentVersion, r.innerStruct.LatestTag)
-	return fmt.Errorf("to upgrade the cloud platform cli, run `brew update && brew upgrade cloud-platform-cli` or grab the latest version from https://github.com/ministryofjustice/cloud-platform-cli/releases")
+	return fmt.Errorf("To upgrade the Cloud Platform CLI, please refer to the Cloud Platform User Guide https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/cloud-platform-cli.html#keeping-up-to-date")
 }
 
 func (r *myRelease) getLatestReleaseInfo() error {

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -61,7 +61,7 @@ func (r *Release) isLatestVersion() (error, bool) {
 
 func (r *Release) informUserToUpgrade() error {
 	fmt.Printf("Update required. Current version: %s, Latest version: %s\n\n", r.innerStruct.CurrentVersion, r.innerStruct.LatestTag)
-	return fmt.Errorf("To update the Cloud Platform CLI, please refer to the Cloud Platform User Guide https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/cloud-platform-cli.html#keeping-up-to-date")
+	return fmt.Errorf("to update the Cloud Platform CLI, please refer to the Cloud Platform User Guide https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/cloud-platform-cli.html#keeping-up-to-date")
 }
 
 func (r *myRelease) getLatestReleaseInfo() error {


### PR DESCRIPTION
This pull request Changes the update messaging to refer to the user guide instead of explicitly using Homebrew, this is because the Analytical Platform ship this tool as part of our cloud development environment base image and is misleading for users.

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 