### PR TITLE
feat: 🎸 skip creating a pr for rds drift if one already exists

### DIFF
--- a/pkg/environment/createPR.go
+++ b/pkg/environment/createPR.go
@@ -29,6 +29,15 @@ func createPR(description, namespace, ghToken, repo string) func(github.GithubIf
 		useGhTokenCmd.Start() //nolint:errcheck
 		useGhTokenCmd.Wait()  //nolint:errcheck
 
+		pulls, err := gh.ListOpenPRs(namespace)
+		if err != nil {
+			fmt.Printf("warning: Error listing open prs: %v\n", err)
+		}
+
+		if len(pulls) > 0 {
+			return "", errors.New("a pr is already open for this namespace, skipping opening another")
+		}
+
 		checkCmd := exec.Command("/bin/sh", "-c", "git checkout -b "+branchName)
 		checkCmd.Start() //nolint:errcheck
 		checkCmd.Wait()  //nolint:errcheck
@@ -47,15 +56,6 @@ func createPR(description, namespace, ghToken, repo string) func(github.GithubIf
 		pushCmd := exec.Command("/bin/sh", "-c", "git push --set-upstream origin "+branchName)
 		pushCmd.Start() //nolint:errcheck
 		pushCmd.Wait()  //nolint:errcheck
-
-		pulls, err := gh.ListOpenPRs(namespace)
-		if err != nil {
-			fmt.Printf("warning: Error listing open prs: %v\n", err)
-		}
-
-		if len(pulls) > 0 {
-			return "", errors.New("a pr is already open for this namespace, skipping opening another")
-		}
 
 		return gh.CreatePR(branchName, namespace, description)
 	}

--- a/pkg/environment/createPR.go
+++ b/pkg/environment/createPR.go
@@ -54,7 +54,7 @@ func createPR(description, namespace, ghToken, repo string) func(github.GithubIf
 		}
 
 		if len(pulls) > 0 {
-			return "", errors.New("a pr is already open for this namespace, skipping opening another...")
+			return "", errors.New("a pr is already open for this namespace, skipping opening another")
 		}
 
 		return gh.CreatePR(branchName, namespace, description)

--- a/pkg/environment/updateVersion.go
+++ b/pkg/environment/updateVersion.go
@@ -64,7 +64,6 @@ func checkRdsAndUpdate(tfErr, tfDir string) (string, []string, error) {
 	}
 
 	for i := 0; i < matches.TotalVersionMismatches; i++ {
-
 		moduleName := matches.ModuleNames[i][0]
 		actualDbVersion := matches.Versions[i][0]
 		terraformDbVersion := matches.Versions[i][1]

--- a/pkg/github/client_iface.go
+++ b/pkg/github/client_iface.go
@@ -14,4 +14,5 @@ type GithubIface interface {
 	GetChangedFiles(int) ([]*github.CommitFile, error)
 	IsMerged(prNumber int) (bool, error)
 	CreatePR(branchName, namespace, description string) (string, error)
+	ListOpenPRs(namespace string) ([]*github.PullRequest, error)
 }

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -26,6 +26,10 @@ func (m *mockGithub) Create(ctx context.Context, owner string, repo string, pr *
 	return nil, nil, nil
 }
 
+func (m *mockGithub) List(ctx context.Context, owner, repo string, opts *github.PullRequestListOptions) ([]*github.PullRequest, *github.Response, error) {
+	return nil, nil, nil
+}
+
 func TestNewGithubClient(t *testing.T) {
 	type args struct {
 		config *GithubClientConfig


### PR DESCRIPTION
Currently, duplicate PRs are being created when the pipeline runs overnight/ over the weekend and hits the same error, this creates more work for the reviewer.

Skip PR creation and posting to slack if a PR already exists