### PR TITLE
Pass out the plan file from tf plan cmd AND pass it into the tf apply cmd

### DIFF
--- a/doc/cloud-platform_terraform_apply.md
+++ b/doc/cloud-platform_terraform_apply.md
@@ -13,6 +13,8 @@ cloud-platform terraform apply [flags]
       --aws-region string              [required] aws region to use
       --aws-secret-access-key string   [required] Secret access key of service account to be used by terraform
   -h, --help                           help for apply
+      --is-pipeline                    [required] if the terraform is being executed from the pipeline
+      --plan-filename string           [optional] the plan filename to be output from the terraform plan or used for the terraform apply eg. 'plan-$PR_NUM.out' [default] ''
       --redact                         Redact the terraform output before printing (default true)
       --terraform-version string       [optional] the terraform version to use. (default "1.2.5")
       --workdir string                 [optional] the terraform working directory to perform terraform operation [default] . (default ".")

--- a/doc/cloud-platform_terraform_check-divergence.md
+++ b/doc/cloud-platform_terraform_check-divergence.md
@@ -13,6 +13,8 @@ cloud-platform terraform check-divergence [flags]
       --aws-region string              [required] aws region to use
       --aws-secret-access-key string   [required] Secret access key of service account to be used by terraform
   -h, --help                           help for check-divergence
+      --is-pipeline                    [required] if the terraform is being executed from the pipeline
+      --plan-filename string           [optional] the plan filename to be output from the terraform plan or used for the terraform apply eg. 'plan-$PR_NUM.out' [default] ''
       --redact                         Redact the terraform output before printing (default true)
       --terraform-version string       [optional] the terraform version to use. (default "1.2.5")
       --workdir string                 [optional] the terraform working directory to perform terraform operation [default] . (default ".")

--- a/doc/cloud-platform_terraform_plan.md
+++ b/doc/cloud-platform_terraform_plan.md
@@ -13,6 +13,8 @@ cloud-platform terraform plan [flags]
       --aws-region string              [required] aws region to use
       --aws-secret-access-key string   [required] Secret access key of service account to be used by terraform
   -h, --help                           help for plan
+      --is-pipeline                    [required] if the terraform is being executed from the pipeline
+      --plan-filename string           [optional] the plan filename to be output from the terraform plan or used for the terraform apply eg. 'plan-$PR_NUM.out' [default] ''
       --redact                         Redact the terraform output before printing (default true)
       --terraform-version string       [optional] the terraform version to use. (default "1.2.5")
       --workdir string                 [optional] the terraform working directory to perform terraform operation [default] . (default ".")

--- a/pkg/commands/terraform.go
+++ b/pkg/commands/terraform.go
@@ -33,9 +33,13 @@ func addTerraformCmd(topLevel *cobra.Command) {
 			if tf.Workspace == "" {
 				contextLogger.Fatal("Workspace is required")
 			}
+
+			if tf.IsPipeline && tf.PlanFilename == "" {
+				contextLogger.Fatal("When running in the pipeline you must provide a plan filename")
+			}
+
 			tfCli, err := terraform.NewTerraformCLI(&tf)
 			if err != nil {
-
 				contextLogger.Fatal(err)
 			}
 
@@ -65,6 +69,11 @@ func addTerraformCmd(topLevel *cobra.Command) {
 			if tf.Workspace == "" {
 				contextLogger.Fatal("Workspace is required")
 			}
+
+			if tf.IsPipeline && tf.PlanFilename == "" {
+				contextLogger.Fatal("When running in the pipeline you must provide a plan filename")
+			}
+
 			tfCli, err := terraform.NewTerraformCLI(&tf)
 			if err != nil {
 				contextLogger.Fatal(err)
@@ -146,6 +155,8 @@ func addCommonFlags(cmd *cobra.Command, tf *terraform.TerraformCLIConfig) {
 	cmd.PersistentFlags().StringVarP(&tf.Workspace, "workspace", "w", "", "[required] workspace where terraform is going to be executed")
 	cmd.PersistentFlags().StringVar(&tf.Version, "terraform-version", "1.2.5", "[optional] the terraform version to use.")
 	cmd.PersistentFlags().BoolVar(&tf.Redacted, "redact", true, "Redact the terraform output before printing")
+	cmd.PersistentFlags().BoolVar(&tf.IsPipeline, "is-pipeline", false, "[required] if the terraform is being executed from the pipeline")
+	cmd.PersistentFlags().StringVar(&tf.PlanFilename, "plan-filename", "", "[optional] the plan filename to be output from the terraform plan or used for the terraform apply eg. 'plan-$PR_NUM.out' [default] ''")
 
 	_ = cmd.MarkPersistentFlagRequired("aws-access-key-id")
 	_ = cmd.MarkPersistentFlagRequired("aws-secret-access-key")

--- a/pkg/environment/createPlanSummary.go
+++ b/pkg/environment/createPlanSummary.go
@@ -56,7 +56,7 @@ func CreateCommentBody(tfPlan *tfjson.Plan) string {
 	body = fmt.Sprintf(body, len(resourcesToCreate), len(resourcesToDelete), len(resourcesToUpdate), len(resourcesToReplace), len(resourcesUnchanged), details("create", "+", resourcesToCreate), details("destroy", "-", resourcesToDelete), details("update", "!", resourcesToUpdate), details("replace", "-+", resourcesToReplace))
 
 	if len(resourcesToCreate) == 0 && len(resourcesToReplace) == 0 && len(resourcesToUpdate) == 0 && len(resourcesToDelete) == 0 {
-		body = "\n```diff\n+ There are no terraform changes to apply```\n"
+		body = "\n```diff\n+ There are no terraform changes to apply\n```\n"
 	}
 
 	return body

--- a/pkg/environment/createPlanSummary_test.go
+++ b/pkg/environment/createPlanSummary_test.go
@@ -104,7 +104,7 @@ func Test_CreateCommentBody(t *testing.T) {
 		want string
 	}{
 		{
-			"GIVEN a terraform plan with no changes THEN return a comment body stating so", args{tfNoChangesPlan}, "\n```diff\n+ There are no terraform changes to apply```\n",
+			"GIVEN a terraform plan with no changes THEN return a comment body stating so", args{tfNoChangesPlan}, "\n```diff\n+ There are no terraform changes to apply\n```\n",
 		},
 		{
 			"GIVEN a terraform plan with CREATE changes THEN return a comment body with correct changes", args{tfChangesPlan01}, createChangesExpected,

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -28,14 +28,16 @@ var (
 // TerraformCLI is the client that wraps around terraform-exec
 // to execute Terraform cli commands
 type TerraformCLI struct {
-	Tf          terraformExec
-	WorkingDir  string
-	Workspace   string
-	ApplyVars   []tfexec.ApplyOption
-	DestroyVars []tfexec.DestroyOption
-	PlanVars    []tfexec.PlanOption
-	InitVars    []tfexec.InitOption
-	Redacted    bool
+	Tf           terraformExec
+	WorkingDir   string
+	Workspace    string
+	ApplyVars    []tfexec.ApplyOption
+	DestroyVars  []tfexec.DestroyOption
+	PlanVars     []tfexec.PlanOption
+	InitVars     []tfexec.InitOption
+	Redacted     bool
+	IsPipeline   bool
+	PlanFilename string
 }
 
 // TerraformCLIConfig configures the Terraform client
@@ -58,6 +60,10 @@ type TerraformCLIConfig struct {
 	Version string
 	// Redacted is the flag to enable/disable redacting the terraform before printing output.
 	Redacted bool
+	// if the terraform is being executed from the pipeline
+	IsPipeline bool
+	// Plan Filename to be output from plan or to be used in apply
+	PlanFilename string
 }
 
 // NewTerraformCLI creates a terraform-exec client and configures and
@@ -104,14 +110,16 @@ func NewTerraformCLI(config *TerraformCLIConfig) (*TerraformCLI, error) {
 	}
 
 	client := &TerraformCLI{
-		Tf:          tf,
-		WorkingDir:  config.WorkingDir,
-		Workspace:   config.Workspace,
-		ApplyVars:   config.ApplyVars,
-		DestroyVars: config.DestroyVars,
-		PlanVars:    config.PlanVars,
-		InitVars:    config.InitVars,
-		Redacted:    config.Redacted,
+		Tf:           tf,
+		WorkingDir:   config.WorkingDir,
+		Workspace:    config.Workspace,
+		ApplyVars:    config.ApplyVars,
+		DestroyVars:  config.DestroyVars,
+		PlanVars:     config.PlanVars,
+		InitVars:     config.InitVars,
+		Redacted:     config.Redacted,
+		IsPipeline:   config.IsPipeline,
+		PlanFilename: config.PlanFilename,
 	}
 
 	return client, nil
@@ -168,6 +176,11 @@ func (t *TerraformCLI) Apply(ctx context.Context, w io.Writer) error {
 	t.Tf.SetStdout(w)
 	t.Tf.SetStderr(w)
 
+	if t.IsPipeline && t.PlanFilename != "" {
+		outOptions := tfexec.DirOrPlan(t.PlanFilename)
+		t.ApplyVars = append(t.ApplyVars, outOptions)
+	}
+
 	if err := t.Tf.Apply(ctx, t.ApplyVars...); err != nil {
 		return err
 	}
@@ -192,8 +205,11 @@ func (t *TerraformCLI) Plan(ctx context.Context, w io.Writer) (bool, error) {
 	t.Tf.SetStdout(w)
 	t.Tf.SetStderr(w)
 
-	outOptions := tfexec.Out("plan.out")
-	t.PlanVars = append(t.PlanVars, outOptions)
+	if t.IsPipeline && t.PlanFilename != "" {
+		outOptions := tfexec.Out(t.PlanFilename)
+		t.PlanVars = append(t.PlanVars, outOptions)
+	}
+
 	diff, err := t.Tf.Plan(ctx, t.PlanVars...)
 	if err != nil {
 		return false, err

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -192,6 +192,8 @@ func (t *TerraformCLI) Plan(ctx context.Context, w io.Writer) (bool, error) {
 	t.Tf.SetStdout(w)
 	t.Tf.SetStderr(w)
 
+	outOptions := tfexec.Out("plan.out")
+	t.PlanVars = append(t.PlanVars, outOptions)
 	diff, err := t.Tf.Plan(ctx, t.PlanVars...)
 	if err != nil {
 		return false, err

--- a/pkg/terraform/terraform_test.go
+++ b/pkg/terraform/terraform_test.go
@@ -27,7 +27,7 @@ func NewTestTerraformCLI(config *TerraformCLIConfig, tfMock *mocks.TerraformExec
 		m.On("Init", mock.Anything).Return(nil)
 		m.On("Apply", mock.Anything).Return(nil)
 		m.On("Destroy", mock.Anything).Return(nil)
-		m.On("Plan", mock.Anything).Return(true, nil)
+		m.On("Plan", mock.Anything, mock.Anything).Return(true, nil)
 		m.On("Output", mock.Anything).Return(nil, nil)
 		m.On("Show", mock.Anything).Return(nil, nil)
 		m.On("WorkspaceNew", mock.Anything, mock.Anything).Return(nil)


### PR DESCRIPTION
1/2 PRs

This PR outputs the plan file for the `cloud-platform terraform plan` command and takes a plan file to as an argument to be used in a `cloud-platform terraform apply`.

The next PR will push the plan file from the pipeline to our s3 bucket and respectively pulls the correct file from s3 to be used in `terraform apply`, these changes will be in our [`terraform-concourse` repo here](https://github.com/ministryofjustice/cloud-platform-terraform-concourse/pull/429)

- add flags to indicate whether we should output/ use a plan file
- output plan in the dir that the `terraform plan` is running from
- use plan file in terraform apply
- fix environments plan comment format