### PR TITLE
perf: ⚡️ run apply namespaces in apply pipeline concurrently

### DIFF
--- a/pkg/cluster/delete_utils/utils.go
+++ b/pkg/cluster/delete_utils/utils.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/ministryofjustice/cloud-platform-cli/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -37,7 +38,7 @@ func AbortIfUserNamespacesExist(namespaces []v1.Namespace, systemNamespaces []st
 			continue
 		}
 
-		isUserNamespace := !contains(systemNamespaces, ns.Name)
+		isUserNamespace := !util.Contains(systemNamespaces, ns.Name)
 
 		if isUserNamespace {
 			userNamespaces = append(userNamespaces, ns.Name)
@@ -73,7 +74,7 @@ func CheckClusterIsDestroyed(clusterName string, eksAPI EKSClient) error {
 		clusterValues = append(clusterValues, *val)
 	}
 
-	isDeleted := !contains(clusterValues, clusterName)
+	isDeleted := !util.Contains(clusterValues, clusterName)
 
 	if !isDeleted {
 		return fmt.Errorf("cluster has not successfully deleted")
@@ -91,7 +92,6 @@ func CheckVpcIsDestroyed(vpcID string, ec2API EC2Client) error {
 			{Name: aws.String("tag:business-unit"), Values: []*string{aws.String("Platforms")}},
 		},
 	})
-
 	if err != nil {
 		return fmt.Errorf("failed to list vpcs: %w", err)
 	}
@@ -102,22 +102,11 @@ func CheckVpcIsDestroyed(vpcID string, ec2API EC2Client) error {
 		vpcValues = append(vpcValues, *val.VpcId)
 	}
 
-	isDeleted := !contains(vpcValues, vpcID)
+	isDeleted := !util.Contains(vpcValues, vpcID)
 
 	if !isDeleted {
 		return fmt.Errorf("vpc has not successfully deleted")
 	}
 
 	return nil
-}
-
-// Contains checks if a string is present in a slice
-func contains(s []string, str string) bool {
-	for _, v := range s {
-		if v == str {
-			return true
-		}
-	}
-
-	return false
 }

--- a/pkg/cluster/delete_utils/utils_test.go
+++ b/pkg/cluster/delete_utils/utils_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/eks/eksiface"
 	"github.com/ministryofjustice/cloud-platform-cli/pkg/client"
+	"github.com/ministryofjustice/cloud-platform-cli/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -131,7 +132,7 @@ func Test_contains(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := contains(tt.args.s, tt.args.str); got != tt.want {
+			if got := util.Contains(tt.args.s, tt.args.str); got != tt.want {
 				t.Errorf("contains() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/environment/applier.go
+++ b/pkg/environment/applier.go
@@ -157,12 +157,6 @@ func (m *ApplierImpl) TerraformInitAndPlan(namespace, directory string) (*tfjson
 		return nil, "", errors.New("unable to do Terraform Plan: " + err.Error())
 	}
 
-	// ignore if any changes or no changes.
-	_, err = terraform.Plan(context.Background())
-	if err != nil {
-		return nil, "", errors.New("unable to do Terraform Plan: " + err.Error())
-	}
-
 	return tfPlan, out.String(), nil
 }
 

--- a/pkg/util/concurrent.go
+++ b/pkg/util/concurrent.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"sync"
+)
+
+func Generator(done <-chan bool, data ...string) <-chan string {
+	readStream := make(chan string)
+	go func() {
+		defer close(readStream)
+		for _, s := range data {
+			select {
+			case <-done:
+				return
+			case readStream <- s:
+			}
+		}
+	}()
+
+	return readStream
+}
+
+func FanIn(done <-chan bool, channels ...<-chan string) <-chan string {
+	var wg sync.WaitGroup
+	multiplexedStream := make(chan string)
+
+	multiplex := func(c <-chan string) {
+		defer wg.Done()
+		for i := range c {
+			select {
+			case <-done:
+				return
+			case multiplexedStream <- i:
+			}
+		}
+	}
+
+	wg.Add(len(channels))
+	for _, c := range channels {
+		go multiplex(c)
+	}
+
+	go func() {
+		wg.Wait()
+		close(multiplexedStream)
+	}()
+
+	return multiplexedStream
+}

--- a/pkg/util/concurrent_test.go
+++ b/pkg/util/concurrent_test.go
@@ -1,0 +1,97 @@
+package util_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ministryofjustice/cloud-platform-cli/pkg/util"
+)
+
+func Test_Generator(t *testing.T) {
+	test01 := []string{"foo", "bar", "baz"}
+	test02 := []string{}
+
+	type args struct {
+		data []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{"GIVEN some string array data THEN write the data into channel AND return a readonly channel", args{test01}, test01},
+		{"GIVEN an empty string array THEN write nothing into the channel AND close the channel properly to avoid being locked", args{test02}, test02},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			done := make(chan bool)
+			defer close(done)
+			got := util.Generator(done, tt.args.data...)
+
+			gotFromChannel := []string{}
+
+			for res := range got {
+				gotFromChannel = append(gotFromChannel, res)
+			}
+
+			if !reflect.DeepEqual(gotFromChannel, tt.want) {
+				t.Errorf("Generator() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_FanIn(t *testing.T) {
+	test01 := [][]string{{"foo"}, {"bar"}, {"baz"}}
+	test01Combined := []string{"foo", "bar", "baz"}
+	test02 := [][]string{}
+	test02Combined := []string{}
+
+	type args struct {
+		channels [][]string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{"GIVEN many channels with data on THEN return a single channel with the combined data", args{test01}, test01Combined},
+		{"GIVEN an empty input channels array THEN return a single channel AND close the channels properly to avoid being locked", args{test02}, test02Combined},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			done := make(chan bool)
+			defer close(done)
+
+			channels := make([]<-chan string, len(tt.args.channels))
+
+			for i, data := range tt.args.channels {
+				newChan := make(chan string, len(data))
+				for _, chanData := range data {
+					newChan <- chanData
+				}
+				close(newChan)
+				channels[i] = newChan
+			}
+
+			got := util.FanIn(done, channels...)
+
+			gotFromChannel := []string{}
+
+			for res := range got {
+				gotFromChannel = append(gotFromChannel, res)
+			}
+
+			if len(tt.want) != len(gotFromChannel) {
+				t.Errorf("FanIn() = %v, want %v", got, tt.want)
+			}
+
+			for _, val := range gotFromChannel {
+				if !util.Contains(tt.want, val) {
+					t.Errorf("FanIn() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -199,3 +199,13 @@ func GetGithubRawContents(rawUrl string) ([]byte, error) {
 	}
 	return data, nil
 }
+
+func Contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -350,3 +350,37 @@ func TestGetGithubRawContents(t *testing.T) {
 		})
 	}
 }
+
+func Test_contains(t *testing.T) {
+	type args struct {
+		s   []string
+		str string
+	}
+
+	validStrArr := []string{"testVal"}
+	validArgs := args{
+		s:   validStrArr,
+		str: "testVal",
+	}
+
+	invalidArgs := args{
+		s:   validStrArr,
+		str: "incorrect",
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{name: "GIVEN a string and that string is also in the string array THEN return true", args: validArgs, want: true},
+		{name: "GIVEN a string and that string is NOT in the string array THEN return false", args: invalidArgs, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Contains(tt.args.s, tt.args.str); got != tt.want {
+				t.Errorf("contains() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Continue chunking and batching namespaces across different pipelines but within those pipelines run the applies concurrently.

This PR covers:

- if the pipeline fails a namespace apply, then fail silently but collect all the errored namespaces and log them so we can inspect them if we need
- rewrite the namespace apply so we can take advantage of go routines and speed up apply pipelines
- remove duplicate call to plan
- explicitly pass a namespace arg to `destroyNamespace`, `planNamespace` and `applyNamespace` to fix a bug where incorrectly structs were accessed during parallel runs
- move contains fn from `deleteutils` to `util`
- project test coverage increased from 68.5% -> 72.0%

performance results:

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-parallel-test/builds/2 (one errored namespace can be found at the bottom of the log)

```
duration	34m 43s Which cuts the build time in more than half (compared to the same run on current apply live 1h 20m)
```

build peaked (running on worker-3) Another apply pipeline was running at the same time on the same worker, but another was running on worker 1 at the same time

```
concourse-worker-0               19m          3170Mi
concourse-worker-1               18m          5180Mi
concourse-worker-2               566m         3791Mi
concourse-worker-3               3418m        5885Mi
```

Note current pod limits are (if we raise the limits go will utilise those extra resources):

```
    Limits:
      cpu:     4
      memory:  8Gi
    Requests:
      cpu:     1
      memory:  1Gi
```