### PR TITLE
feat: add create-custom-cluster and test-custom-cluster

### DIFF
--- a/doc/cloud-platform_pipeline.md
+++ b/doc/cloud-platform_pipeline.md
@@ -18,5 +18,7 @@ Cloud Platform pipeline actions
 
 * [cloud-platform](cloud-platform.md)	 - Multi-purpose CLI from the Cloud Platform team
 * [cloud-platform pipeline cordon-and-drain](cloud-platform_pipeline_cordon-and-drain.md)	 - cordon and drain a node group on a cluster
+* [cloud-platform pipeline create-custom-cluster](cloud-platform_pipeline_create-custom-cluster.md)	 - create a custom cloud-platform cluster via the pipeline
 * [cloud-platform pipeline delete-cluster](cloud-platform_pipeline_delete-cluster.md)	 - delete a cloud-platform cluster via the pipeline
+* [cloud-platform pipeline test-custom-cluster](cloud-platform_pipeline_test-custom-cluster.md)	 - test a custom cloud-platform cluster via the pipeline
 

--- a/doc/cloud-platform_pipeline_create-custom-cluster.md
+++ b/doc/cloud-platform_pipeline_create-custom-cluster.md
@@ -1,0 +1,41 @@
+## cloud-platform pipeline create-custom-cluster
+
+create a custom cloud-platform cluster via the pipeline
+
+### Synopsis
+
+
+Running this command will create a custom eks cluster in the cloud-platform aws account.
+
+   This command will run remotely in the pipeline
+
+Optionally you can pass a branch name to use for the pipeline run, default is "main"
+
+   ** You _must_ have the fly cli installed **
+   --> https://concourse-ci.org/fly.html
+
+   ** You must also have wget installed **
+   --> brew install wget
+
+
+```
+cloud-platform pipeline create-custom-cluster [flags]
+```
+
+### Options
+
+```
+  -b, --branch-name string   branch name to use for pipeline run (default: main) (default "main")
+  -h, --help                 help for create-custom-cluster
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform pipeline](cloud-platform_pipeline.md)	 - Cloud Platform pipeline actions
+

--- a/doc/cloud-platform_pipeline_test-custom-cluster.md
+++ b/doc/cloud-platform_pipeline_test-custom-cluster.md
@@ -1,0 +1,45 @@
+## cloud-platform pipeline test-custom-cluster
+
+test a custom cloud-platform cluster via the pipeline
+
+### Synopsis
+
+
+Running this command will test a custom eks cluster in the cloud-platform aws account.
+
+   The delete will run remotely in the pipeline
+
+You must have the following environment variables set, or passed via arguments:
+	- a cluster name
+
+Optionally you can pass a branch name to use for the pipeline run, default is "main"
+
+   ** You _must_ have the fly cli installed **
+   --> https://concourse-ci.org/fly.html
+
+   ** You must also have wget installed **
+   --> brew install wget
+
+
+```
+cloud-platform pipeline test-custom-cluster [flags]
+```
+
+### Options
+
+```
+  -b, --branch-name string    branch name to use for pipeline run (default: main) (default "main")
+      --cluster-name string   cluster to delete
+  -h, --help                  help for test-custom-cluster
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform pipeline](cloud-platform_pipeline.md)	 - Cloud Platform pipeline actions
+

--- a/pkg/commands/pipeline.go
+++ b/pkg/commands/pipeline.go
@@ -74,7 +74,7 @@ func addPipelineCordonAndDrainClusterCmd(toplevel *cobra.Command) {
 	toplevel.AddCommand(cmd)
 }
 
-func (opt *pipelineOptions) addPipelineDeleteClusterFlags(cmd *cobra.Command) {
+func (opt *pipelineOptions) addGenericClusterFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&cliOpt.Name, "cluster-name", "", "cluster to delete")
 	cmd.Flags().StringVarP(&cliOpt.BranchName, "branch-name", "b", "main", "branch name to use for pipeline run (default: main)")
 }
@@ -118,7 +118,81 @@ func addPipelineDeleteClusterCmd(toplevel *cobra.Command) {
 		},
 	}
 
-	cliOpt.addPipelineDeleteClusterFlags(cmd)
+	cliOpt.addGenericClusterFlags(cmd)
+	toplevel.AddCommand(cmd)
+}
+
+func (opt *pipelineOptions) addCreateCustomPipelineClusterFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&cliOpt.BranchName, "branch-name", "b", "main", "branch name to use for pipeline run (default: main)")
+}
+
+func addCreateCustomClusterCmd(toplevel *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "create-custom-cluster",
+		Short: `create a custom cloud-platform cluster via the pipeline`,
+		Long: heredoc.Doc(`
+
+			Running this command will create a custom eks cluster in the cloud-platform aws account.
+
+      This command will run remotely in the pipeline
+
+			Optionally you can pass a branch name to use for the pipeline run, default is "main"
+
+      ** You _must_ have the fly cli installed **
+      --> https://concourse-ci.org/fly.html
+
+      ** You must also have wget installed **
+      --> brew install wget
+`),
+		PreRun: upgradeIfNotLatest,
+		Run: func(cmd *cobra.Command, args []string) {
+			pipeline.CreateCustomPipelineShellCmds(cliOpt.BranchName)
+		},
+	}
+
+	cliOpt.addCreateCustomPipelineClusterFlags(cmd)
+	toplevel.AddCommand(cmd)
+}
+
+func addTestCustomClusterCmd(toplevel *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "test-custom-cluster",
+		Short: `test a custom cloud-platform cluster via the pipeline`,
+		Long: heredoc.Doc(`
+
+			Running this command will test a custom eks cluster in the cloud-platform aws account.
+
+      The delete will run remotely in the pipeline
+
+			You must have the following environment variables set, or passed via arguments:
+				- a cluster name
+
+			Optionally you can pass a branch name to use for the pipeline run, default is "main"
+
+      ** You _must_ have the fly cli installed **
+      --> https://concourse-ci.org/fly.html
+
+      ** You must also have wget installed **
+      --> brew install wget
+`),
+		PreRun: upgradeIfNotLatest,
+		Run: func(cmd *cobra.Command, args []string) {
+			contextLogger := log.WithFields(log.Fields{"subcommand": "test-custom-cluster"})
+			cliOpt.MaxNameLength = 12
+
+			if cliOpt.Name == "" {
+				contextLogger.Fatal("--cluster-name is required")
+			}
+
+			if err := cliOpt.IsNameValid(); err != nil {
+				contextLogger.Fatal(err)
+			}
+
+			pipeline.TestCustomPipelineShellCmds(cliOpt.Name, cliOpt.BranchName)
+		},
+	}
+
+	cliOpt.addGenericClusterFlags(cmd)
 	toplevel.AddCommand(cmd)
 }
 
@@ -127,6 +201,8 @@ func addPipelineCmd(topLevel *cobra.Command) {
 
 	addPipelineDeleteClusterCmd(pipelineCmd)
 	addPipelineCordonAndDrainClusterCmd(pipelineCmd)
+	addCreateCustomClusterCmd(pipelineCmd)
+	addTestCustomClusterCmd(pipelineCmd)
 }
 
 var pipelineCmd = &cobra.Command{

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -34,3 +34,17 @@ func CordonAndDrainPipelineShellCmds(clusterName, nodeGroup string) {
 	runCmd("fly", []string{"--target", "manager", "trigger-job", "-j", "cordon-and-drain-nodes/cordon-and-drain-nodes"})
 	fmt.Println("Cordoning and Draining... https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/cordon-and-drain-nodes/jobs/cordon-and-drain-nodes/builds/latest")
 }
+
+func CreateCustomPipelineShellCmds(branchName string) {
+	runCmd("fly", []string{"--target", "manager", "login", "--team-name", "main", "--concourse-url", "https://concourse.cloud-platform.service.justice.gov.uk/"})
+	runCmd("bash", []string{"-c", "wget -qO- https://raw.githubusercontent.com/ministryofjustice/cloud-platform-terraform-concourse/main/pipelines/manager/main/custom-cluster.yaml | fly --target manager set-pipeline -p custom-cluster -c - -v branch_name=" + branchName})
+	runCmd("fly", []string{"--target", "manager", "trigger-job", "-j", "custom-cluster/create"})
+	fmt.Println("Creating... https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/custom-cluster/jobs/create/builds/latest")
+}
+
+func TestCustomPipelineShellCmds(clusterName string, branchName string) {
+	runCmd("fly", []string{"--target", "manager", "login", "--team-name", "main", "--concourse-url", "https://concourse.cloud-platform.service.justice.gov.uk/"})
+	runCmd("bash", []string{"-c", "wget -qO- https://raw.githubusercontent.com/ministryofjustice/cloud-platform-terraform-concourse/main/pipelines/manager/main/custom-cluster.yaml | fly --target manager set-pipeline -p custom-cluster -c - -v cluster_name=" + clusterName + " -v branch_name=" + branchName})
+	runCmd("fly", []string{"--target", "manager", "trigger-job", "-j", "custom-cluster/custom-integration-tests"})
+	fmt.Println("Testing... https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/custom-cluster/jobs/custom-integration-tests/builds/latest")
+}


### PR DESCRIPTION
## 👀 Purpose

- Adds two new commands:
- `create-custom-cluster` - creates a custom cluster using the `custom-cluster` pipeline
- `test-custom-cluster` - runs integration tests against a cluster

## ♻️ What's changed

- refactored a parameter function to be more generic

## 📝 Notes

-