### PR TITLE
fix: 🐛 ensure that we are running tf in the correct dir

### DIFF
--- a/pkg/environment/apply.go
+++ b/pkg/environment/apply.go
@@ -278,9 +278,13 @@ func (a *Apply) deleteKubectl() (string, error) {
 
 // applyTerraform calls applier -> TerraformInitAndApply and prints the output from applier
 func (a *Apply) applyTerraform() (string, error) {
-	log.Printf("Running Terraform Apply for namespace: %v", a.Options.Namespace)
+	log.Printf("Running Terraform Apply for namespace: %v. In directory %v", a.Options.Namespace, a.Dir)
 
 	tfFolder := a.Dir + "/resources"
+
+	if strings.Contains(a.Dir, a.Options.Namespace) {
+		return "", fmt.Errorf("error running terraform as directory and namespace are not aligned Dir=%v and Namespace=%v", a.Dir, a.Options.Namespace)
+	}
 
 	outputTerraform, err := a.Applier.TerraformInitAndApply(a.Options.Namespace, tfFolder)
 


### PR DESCRIPTION
- There was an unexplained destroy happening, it's possible this was due to a race condition where the namespace and dir were misaligned

- only run the apply if the dir contains the namespace

https://github.com/ministryofjustice/cloud-platform/issues/6680