### PR TITLE
fix: Update Auto Approve Script

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -32,7 +32,7 @@ jobs:
 
       # Upload the original go test log as anhaveyoudebuggedit/gotestfmt-action@v2haveyoudebuggedit/gotestfmt-action@v2 artifact for later review.
       - name: Upload test log
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-log

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-log
+          name: test-log-${{ matrix.os }}
           path: ~/gotest.log
           if-no-files-found: error
 

--- a/scripts/auto_approve.sh
+++ b/scripts/auto_approve.sh
@@ -18,6 +18,13 @@ CHANGED_FILES=$(curl -L \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "https://api.github.com/repos/ministryofjustice/cloud-platform-environments/pulls/$PR/files" |  jq -r '.[].filename')
 
+
+NUM_CHANGED_FILES=$(echo "$CHANGED_FILES" | wc -l)
+
+if [[ "$CHANGED_FILES" == namespaces/live.cloud-platform.service.justice.gov.uk/*/APPLY_PIPELINE_SKIP_THIS_NAMESPACE ]] && [[ "$NUM_CHANGED_FILES" -eq 1 ]] ; then
+    exit 0
+fi
+
 YAML_CHANGES=0
 for f in $CHANGED_FILES; do
     if [[ "$f" == namespaces/live.cloud-platform.service.justice.gov.uk/*/*.yaml ]]; then


### PR DESCRIPTION
- Update the auto approve script to skip commenting on the PR if `APPLY_PIPELINE_SKIP_THIS_NAMESPACE` is the only changed files in the PR 
- Update `go-test.yaml` for deprecated github action version
```
[go-test This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```
- fix test log with the same name in different OS
```
go-test (macos-latest)
Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```