### PR TITLE
fix: allow pipeline to delete gh team filter namespace

### DIFF
--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -28,6 +28,7 @@ var EKS_SYSTEM_NAMESPACES = []string{
 	"tigera-operator",
 	"gatekeeper-system",
 	"cloud-platform-label-pods",
+	"cloud-platform-github-teams-filter",
 }
 
 // DestroyComponents will destroy the Cloud Platform specific components on top of a running cluster. At this point your


### PR DESCRIPTION
- fix below error
```
Please delete these namespaces, and any associated AWS resources, before destroying this cluster: [cloud-platform-github-teams-filter]  subcommand=delete-cluster
```
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/eks-create-test-destroy/jobs/destroy-cluster/builds/292#L674a01a7:6