### PR TITLE
chore: update business unit validator

### DIFF
--- a/pkg/environment/businessUnitValidator.go
+++ b/pkg/environment/businessUnitValidator.go
@@ -5,13 +5,15 @@ type businessUnitValidator struct{}
 func (v *businessUnitValidator) isValid(s string) bool {
 	l := inListValidator{
 		list: []string{
-			"CICA",
-			"HMCTS",
-			"HMPPS",
-			"LAA",
-			"OPG",
-			"Platforms",
 			"HQ",
+			"HMPPS",
+			"OPG",
+			"LAA",
+			"Central Digital",
+			"Technology Services",
+			"HMCTS",
+			"CICA",
+			"Platforms",
 		},
 	}
 	return l.isValid(s)


### PR DESCRIPTION
- Update `businessUnitValidator` so users can input the correct `business-unit`
- Reference:
  - https://technical-guidance.service.justice.gov.uk/documentation/standards/documenting-infrastructure-owners.html#tags-you-should-use
  - https://github.com/ministryofjustice/aws-root-account/blob/814abc38c55f54c15056855e7a9c746b9c8b8fd8/management-account/terraform/organizations-policy-tags.tf#L25-L35