### PR TITLE
Remove the ability to set username and password for prototype and replace with defaults

### DIFF
--- a/pkg/environment/templatePrototype.go
+++ b/pkg/environment/templatePrototype.go
@@ -6,7 +6,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 )
 
-const prototypeTemplateUrl = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/main/namespace-resources-cli-template/resources/prototype"
+const prototypeTemplateUrl = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/prototype-basic-auth/namespace-resources-cli-template/resources/prototype"
 
 func CreateTemplatePrototype() error {
 	re := RepoEnvironment{}

--- a/pkg/environment/templatePrototype.go
+++ b/pkg/environment/templatePrototype.go
@@ -6,7 +6,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 )
 
-const prototypeTemplateUrl = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/prototype-basic-auth/namespace-resources-cli-template/resources/prototype"
+const prototypeTemplateUrl = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/main/namespace-resources-cli-template/resources/prototype"
 
 func CreateTemplatePrototype() error {
 	re := RepoEnvironment{}

--- a/pkg/environment/templatePrototype.go
+++ b/pkg/environment/templatePrototype.go
@@ -28,7 +28,7 @@ func CreateTemplatePrototype() error {
 	s := proto.Namespace.Namespace
 
 	fmt.Printf(`
-Prototype kit websites must be protected by HTTP basic authentication,
+NOTE: Prototype kit websites must be protected by HTTP basic authentication,
 this is so citizens don't mistake them for real government services.
 
 A default username and password will be set for your site, these credentials
@@ -36,8 +36,8 @@ will be stored in plaintext in a public github repository. This means the
 site will not be secure and should not contain information that should not
 be accessible by the public.
 
-Username: prototype
-Password: notarealwebsite
+USERNAME: prototype
+PASSWORD: notarealwebsite
 
 Please run:
 

--- a/pkg/environment/templatePrototype.go
+++ b/pkg/environment/templatePrototype.go
@@ -2,7 +2,6 @@ package environment
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 )
@@ -29,6 +28,17 @@ func CreateTemplatePrototype() error {
 	s := proto.Namespace.Namespace
 
 	fmt.Printf(`
+Prototype kit websites must be protected by HTTP basic authentication,
+this is so citizens don't mistake them for real government services.
+
+A default username and password will be set for your site, these credentials
+will be stored in plaintext in a public github repository. This means the
+site will not be secure and should not contain information that should not
+be accessible by the public.
+
+Username: prototype
+Password: notarealwebsite
+
 Please run:
 
     git add %s
@@ -129,34 +139,6 @@ func promptUserForPrototypeValues() (*Prototype, error) {
 	values.Application = "Gov.UK Prototype Kit"
 	values.SourceCode = "https://github.com/ministryofjustice/" + values.Namespace
 
-	fmt.Println(`
-Prototype kit websites must be protected by HTTP basic
-authentication, so that citizens don't mistake them for
-real government services.
-You need to choose a username and password for your site.
-
-NB: The username and password you choose will be stored in
-plaintext in a public github repository, so do not choose any
-sensitive values here.`)
-
-	q = userQuestion{
-		description: heredoc.Doc(`Please choose a username for your site:
-		`),
-		prompt:    "Username",
-		validator: new(notEmptyValidator),
-	}
-	_ = q.getAnswer()
-	proto.BasicAuthUsername = q.value
-
-	q = userQuestion{
-		description: heredoc.Doc(`Please choose a password for your site:
-		`),
-		prompt:    "Password",
-		validator: new(notEmptyValidator),
-	}
-	_ = q.getAnswer()
-	proto.BasicAuthPassword = q.value
-
 	proto.Namespace = values
 
 	return &proto, nil
@@ -164,11 +146,6 @@ sensitive values here.`)
 
 func createPrototypeFiles(p *Prototype) error {
 	err := createNamespaceFiles(&p.Namespace)
-	if err != nil {
-		return err
-	}
-
-	err = p.appendBasicAuthVariables()
 	if err != nil {
 		return err
 	}
@@ -185,37 +162,6 @@ func createPrototypeFiles(p *Prototype) error {
 	}
 	err = CopyUrlToFile(prototypeTemplateUrl+"/basic-auth.tf", nsdir+"/resources/basic-auth.tf")
 	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// Append the extra terraform variables required by a prototype site
-// to the namespace's resources/variables.tf file
-func (p *Prototype) appendBasicAuthVariables() error {
-	str := `
-## Prototype kit variables
-
-variable "basic-auth-username" {
-  description = "Basic auth. username of the deployed prototype website"
-  default     = "` + p.BasicAuthUsername + `"
-}
-
-variable "basic-auth-password" {
-  description = "Basic auth. password of the deployed prototype website"
-  default     = "` + p.BasicAuthPassword + `"
-}
-`
-	varTf := fmt.Sprintf("%s/%s/resources/variables.tf", namespaceBaseFolder, p.Namespace.Namespace)
-
-	file, err := os.OpenFile(varTf, os.O_APPEND|os.O_WRONLY, 0o644)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	if _, err := file.WriteString(str); err != nil {
 		return err
 	}
 

--- a/pkg/prototype/templatePrototypeDeployment.go
+++ b/pkg/prototype/templatePrototypeDeployment.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	prototypeResourcesUrl = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/main/namespace-resources-cli-template/resources/prototype"
+	prototypeResourcesUrl = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/prototype-basic-auth/namespace-resources-cli-template/resources/prototype"
 )
 
 func CreateDeploymentPrototype(skipDockerFiles bool) error {

--- a/pkg/prototype/templatePrototypeDeployment.go
+++ b/pkg/prototype/templatePrototypeDeployment.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	prototypeResourcesUrl = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/prototype-basic-auth/namespace-resources-cli-template/resources/prototype"
+	prototypeResourcesUrl = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/main/namespace-resources-cli-template/resources/prototype"
 )
 
 func CreateDeploymentPrototype(skipDockerFiles bool) error {


### PR DESCRIPTION
This change relates to issue [#6769](https://github.com/ministryofjustice/cloud-platform/issues/6769)

The authentication on the Prototype sites is there so citizens don't mistake them for real government services. To stop users from mistaking it for secure authentication, we're removing the ability to set custom usernames and passwords as values are displayed in plaintext in a public GitHub repository. The new credentials are set to:
```
USERNAME: prototype
PASSWORD: notarealwebsite
```

This change has been built and tested by creating a local version of the CLI to ensure the changes work as intended.
This has also been tested using the integration tests. All tests passed:
```
Integration tests: 
=== RUN   TestCreatePrototype
--- PASS: TestCreatePrototype (0.58s)
…
=== RUN   TestCreateDeploymentPrototype
--- PASS: TestCreateDeploymentPrototype (0.96s)
=== RUN   TestCreateDeploymentPrototypeWithSkip
--- PASS: TestCreateDeploymentPrototypeWithSkip (0.03s)
PASS
ok  	github.com/ministryofjustice/cloud-platform-cli/pkg/prototype	3.488s
…
```