### PR TITLE
feat: run rds drift checker on merged namespace rds error file

### DIFF
--- a/cmd/cloud-platform.go
+++ b/cmd/cloud-platform.go
@@ -54,6 +54,7 @@ func RootCmdFlags(cmd *cobra.Command) {
 	rootCmd.PersistentFlags().BoolVarP(&SkipVersionCheck, "skip-version-check", "", false, "don't check for updates")
 	_ = viper.BindPFlag("skip-version-check", rootCmd.PersistentFlags().Lookup("skip-version-check"))
 }
+
 func init() {
 	RootCmdFlags(rootCmd)
 }

--- a/doc/cloud-platform_environment.md
+++ b/doc/cloud-platform_environment.md
@@ -27,6 +27,7 @@ Cloud Platform Environment actions
 	the namespace in the given PR Id/Number
 * [cloud-platform environment prototype](cloud-platform_environment_prototype.md)	 - Create a gov.uk prototype kit site on the cloud platform
 * [cloud-platform environment rds](cloud-platform_environment_rds.md)	 - Add an RDS instance to a namespace
+* [cloud-platform environment rds-drift-checker](cloud-platform_environment_rds-drift-checker.md)	 - Detect and correct RDS engine version drift from a CSV file in S3 or locally
 * [cloud-platform environment s3](cloud-platform_environment_s3.md)	 - Add a S3 bucket to a namespace
 * [cloud-platform environment serviceaccount](cloud-platform_environment_serviceaccount.md)	 - Add a serviceaccount to a namespace
 

--- a/doc/cloud-platform_environment_rds-drift-checker.md
+++ b/doc/cloud-platform_environment_rds-drift-checker.md
@@ -1,0 +1,35 @@
+## cloud-platform environment rds-drift-checker
+
+Detect and correct RDS engine version drift from a CSV file in S3 or locally
+
+```
+cloud-platform environment rds-drift-checker <file-location> [flags]
+```
+
+### Examples
+
+```
+Run with a file from S3:
+  cloud-platform environment rds-drift-checker s3://your-bucket/path/to/merged-rds-errored-namespaces.csv
+
+Run with a local CSV file:
+  cloud-platform environment rds-drift-checker file://path/to/merged-rds-errored-namespaces.csv
+
+```
+
+### Options
+
+```
+  -h, --help   help for rds-drift-checker
+```
+
+### Options inherited from parent commands
+
+```
+      --skip-version-check   don't check for updates
+```
+
+### SEE ALSO
+
+* [cloud-platform environment](cloud-platform_environment.md)	 - Cloud Platform Environment actions
+

--- a/pkg/cluster/create_test.go
+++ b/pkg/cluster/create_test.go
@@ -156,7 +156,6 @@ func TestGetVpc(t *testing.T) {
 	if err == nil {
 		t.Errorf("was expecting an error. checkVpc() error = %v", "expected error")
 	}
-
 }
 
 func TestCheckCluster(t *testing.T) {

--- a/pkg/commands/environment.go
+++ b/pkg/commands/environment.go
@@ -43,6 +43,7 @@ func addEnvironmentCmd(topLevel *cobra.Command) {
 		environmentRdsCmd,
 		environmentS3Cmd,
 		environmentSvcCmd,
+		environmentRdsDriftCheckerCmd,
 	}
 
 	for _, cmd := range envSubCommands {
@@ -446,4 +447,19 @@ var environmentDivergenceCmd = &cobra.Command{
 			contextLogger.Fatal(err)
 		}
 	},
+}
+
+var environmentRdsDriftCheckerCmd = &cobra.Command{
+	Use:   "rds-drift-checker <file-location>",
+	Short: "Detect and correct RDS engine version drift from a CSV file in S3 or locally",
+	Example: heredoc.Doc(`
+		Run with a file from S3:
+		  cloud-platform environment rds-drift-checker s3://your-bucket/path/to/merged-rds-errored-namespaces.csv
+
+		Run with a local CSV file:
+		  cloud-platform environment rds-drift-checker file://path/to/merged-rds-errored-namespaces.csv
+	`),
+	Args:   cobra.ExactArgs(1),
+	PreRun: upgradeIfNotLatest,
+	RunE:   environment.RdsDriftChecker,
 }

--- a/pkg/decodeSecret/decodeSecret.go
+++ b/pkg/decodeSecret/decodeSecret.go
@@ -44,7 +44,6 @@ func DecodeSecret(opts *DecodeSecretOptions) error {
 }
 
 func retrieveSecret(namespace, secret string) string {
-
 	// declare cmd variable
 	var cmd *exec.Cmd
 

--- a/pkg/decodeSecret/decodeSecret_test.go
+++ b/pkg/decodeSecret/decodeSecret_test.go
@@ -106,7 +106,6 @@ func TestFormatJson(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error and received nil")
 	}
-
 }
 
 func TestJsonNoDataKey(t *testing.T) {

--- a/pkg/environment/apply.go
+++ b/pkg/environment/apply.go
@@ -287,7 +287,6 @@ func (a *Apply) applyTerraform() (string, error) {
 	}
 
 	outputTerraform, err := a.Applier.TerraformInitAndApply(a.Options.Namespace, tfFolder)
-
 	if err != nil {
 		return "", fmt.Errorf("error running terraform on namespace %s: %v \n %v", a.Options.Namespace, err, outputTerraform)
 	}

--- a/pkg/environment/apply.go
+++ b/pkg/environment/apply.go
@@ -288,25 +288,6 @@ func (a *Apply) applyTerraform() (string, error) {
 
 	outputTerraform, err := a.Applier.TerraformInitAndApply(a.Options.Namespace, tfFolder)
 
-	TEMP_DISABLE_DRIFT := true
-	if a.Options.IsApplyPipeline && err != nil && !TEMP_DISABLE_DRIFT {
-		versionDescription, filenames, updateErr := checkRdsAndUpdate(err.Error(), tfFolder)
-
-		if updateErr != nil {
-			return "", fmt.Errorf("update error running terraform on namespace %s: %s \n %s \n %s", a.Options.Namespace, err.Error(), updateErr.Error(), outputTerraform)
-		}
-
-		description := "\n\n``` " + versionDescription + " ```\n\n" + a.Options.BuildUrl
-
-		prUrl, createErr := createPR(description, a.Options.Namespace, a.Options.GithubToken, "cloud-platform-environments")(a.GithubClient, filenames)
-
-		if createErr != nil {
-			return "", fmt.Errorf("create error running terraform on namespace %s: %v \n %v \n %v", a.Options.Namespace, err, outputTerraform, createErr)
-		}
-
-		postPR(prUrl, a.RequiredEnvVars.SlackWebhookUrl)
-
-	}
 	if err != nil {
 		return "", fmt.Errorf("error running terraform on namespace %s: %v \n %v", a.Options.Namespace, err, outputTerraform)
 	}

--- a/pkg/environment/createPR.go
+++ b/pkg/environment/createPR.go
@@ -34,40 +34,33 @@ func createPR(description, namespace, ghToken, repo string) func(github.GithubIf
 			return "", errors.New("a PR is already open for this namespace, skipping")
 		}
 
-		if err := exec.Command("/bin/sh", "-c", "git checkout main").Run(); err != nil {
-			checkMainCmd := exec.Command("/bin/sh", "-c", "git checkout main")
-			if err := checkMainCmd.Run(); err != nil {
-				return "", fmt.Errorf("failed to checkout main: %w", err)
-			}
+		checkMainCmd := exec.Command("/bin/sh", "-c", "git checkout main")
+		if err := checkMainCmd.Run(); err != nil {
+			return "", fmt.Errorf("failed to checkout main: %w", err)
 		}
-		if err := func() error {
-			checkBranchCmd := exec.Command("/bin/sh", "-c", "git checkout -b "+branchName)
-			return checkBranchCmd.Run()
-		}(); err != nil {
+
+		checkBranchCmd := exec.Command("/bin/sh", "-c", "git checkout -b "+branchName)
+		if err := checkBranchCmd.Run(); err != nil {
 			return "", fmt.Errorf("failed to create new branch: %w", err)
 		}
 
-		if err := func() error {
-			addCmd := exec.Command("/bin/sh", "-c", "git add "+strings.Join(filenames, " "))
-			addCmd.Dir = repoPath
-			return addCmd.Run()
-		}(); err != nil {
+		addCmd := exec.Command("/bin/sh", "-c", "git add "+strings.Join(filenames, " "))
+		addCmd.Dir = repoPath
+		if err := addCmd.Run(); err != nil {
 			return "", fmt.Errorf("failed to git add: %w", err)
 		}
 
-		if err := func() error {
-			commitCmd := exec.Command("/bin/sh", "-c", "git -c user.name='cloud-platform-moj' -c user.email='cloudplatform@justiceuk.onmicrosoft.com' commit -m 'concourse: correcting rds version drift'")
-			commitCmd.Dir = repoPath
-			return commitCmd.Run()
-		}(); err != nil {
+		commitCmd := exec.Command("/bin/sh", "-c",
+			"git -c user.name='cloud-platform-moj' -c user.email='cloudplatform@justiceuk.onmicrosoft.com' commit -m 'concourse: correcting rds version drift'",
+		)
+		commitCmd.Dir = repoPath
+		if err := commitCmd.Run(); err != nil {
 			return "", fmt.Errorf("failed to git commit: %w", err)
 		}
 
-		if err := func() error {
-			pushCmd := exec.Command("/bin/sh", "-c", "git push --set-upstream origin "+branchName)
-			pushCmd.Dir = repoPath
-			return pushCmd.Run()
-		}(); err != nil {
+		pushCmd := exec.Command("/bin/sh", "-c", "git push --set-upstream origin "+branchName)
+		pushCmd.Dir = repoPath
+		if err := pushCmd.Run(); err != nil {
 			return "", fmt.Errorf("failed to push branch: %w", err)
 		}
 

--- a/pkg/environment/createPR.go
+++ b/pkg/environment/createPR.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log"
 	"os/exec"
 	"strings"
 
@@ -14,57 +15,73 @@ import (
 
 func createPR(description, namespace, ghToken, repo string) func(github.GithubIface, []string) (string, error) {
 	b := make([]byte, 2)
-
-	rand.Read(b) //nolint:errcheck
-
+	if _, err := rand.Read(b); err != nil {
+		return func(gh github.GithubIface, files []string) (string, error) {
+			return "", fmt.Errorf("failed to generate random suffix: %w", err)
+		}
+	}
 	fourCharUid := hex.EncodeToString(b)
 	branchName := namespace + "-rds-minor-version-bump-" + fourCharUid
 
 	return func(gh github.GithubIface, filenames []string) (string, error) {
-		removeRemoteCmd := exec.Command("/bin/sh", "-c", "git remote remove origin")
-		removeRemoteCmd.Start() //nolint:errcheck
-		removeRemoteCmd.Wait()  //nolint:errcheck
-
-		useGhTokenCmd := exec.Command("/bin/sh", "-c", "git remote add origin https://"+ghToken+"@github.com/ministryofjustice/"+repo)
-		useGhTokenCmd.Start() //nolint:errcheck
-		useGhTokenCmd.Wait()  //nolint:errcheck
+		repoPath := "namespaces/live.cloud-platform.service.justice.gov.uk/" + namespace + "/resources"
 
 		pulls, err := gh.ListOpenPRs(namespace)
 		if err != nil {
-			fmt.Printf("warning: Error listing open prs: %v\n", err)
+			log.Printf("Warning: error listing open PRs: %v", err)
 		}
-
 		if len(pulls) > 0 {
-			return "", errors.New("a pr is already open for this namespace, skipping opening another")
+			return "", errors.New("a PR is already open for this namespace, skipping")
 		}
 
-		checkCmd := exec.Command("/bin/sh", "-c", "git checkout -b "+branchName)
-		checkCmd.Start() //nolint:errcheck
-		checkCmd.Wait()  //nolint:errcheck
+		if err := exec.Command("/bin/sh", "-c", "git checkout main").Run(); err != nil {
+			checkMainCmd := exec.Command("/bin/sh", "-c", "git checkout main")
+			if err := checkMainCmd.Run(); err != nil {
+				return "", fmt.Errorf("failed to checkout main: %w", err)
+			}
+		}
+		if err := func() error {
+			checkBranchCmd := exec.Command("/bin/sh", "-c", "git checkout -b "+branchName)
+			return checkBranchCmd.Run()
+		}(); err != nil {
+			return "", fmt.Errorf("failed to create new branch: %w", err)
+		}
 
-		strFiles := strings.Join(filenames, " ")
-		cmd := exec.Command("/bin/sh", "-c", "git add "+strFiles)
-		cmd.Dir = "namespaces/live.cloud-platform.service.justice.gov.uk/" + namespace + "/resources"
-		cmd.Start() //nolint:errcheck
-		cmd.Wait()  //nolint:errcheck
+		if err := func() error {
+			addCmd := exec.Command("/bin/sh", "-c", "git add "+strings.Join(filenames, " "))
+			addCmd.Dir = repoPath
+			return addCmd.Run()
+		}(); err != nil {
+			return "", fmt.Errorf("failed to git add: %w", err)
+		}
 
-		commitCmd := exec.Command("/bin/sh", "-c", "git -c user.name='cloud-platform-moj' -c user.email='platforms+githubuser@digital.justice.gov.uk' commit -m 'concourse: correcting rds version drift'")
-		commitCmd.Dir = "namespaces/live.cloud-platform.service.justice.gov.uk/" + namespace + "/resources"
-		commitCmd.Start() //nolint:errcheck
-		commitCmd.Wait()  //nolint:errcheck
+		if err := func() error {
+			commitCmd := exec.Command("/bin/sh", "-c", "git -c user.name='cloud-platform-moj' -c user.email='cloudplatform@justiceuk.onmicrosoft.com' commit -m 'concourse: correcting rds version drift'")
+			commitCmd.Dir = repoPath
+			return commitCmd.Run()
+		}(); err != nil {
+			return "", fmt.Errorf("failed to git commit: %w", err)
+		}
 
-		pushCmd := exec.Command("/bin/sh", "-c", "git push --set-upstream origin "+branchName)
-		pushCmd.Start() //nolint:errcheck
-		pushCmd.Wait()  //nolint:errcheck
+		if err := func() error {
+			pushCmd := exec.Command("/bin/sh", "-c", "git push --set-upstream origin "+branchName)
+			pushCmd.Dir = repoPath
+			return pushCmd.Run()
+		}(); err != nil {
+			return "", fmt.Errorf("failed to push branch: %w", err)
+		}
 
-		return gh.CreatePR(branchName, namespace, description)
+		prUrl, err := gh.CreatePR(branchName, namespace, description)
+		if err != nil {
+			return "", fmt.Errorf("failed to create PR: %w", err)
+		}
+
+		return prUrl, nil
 	}
 }
 
 func postPR(prUrl, slackWebhookUrl string) {
-	slackErr := slack.PostToAsk(prUrl, slackWebhookUrl)
-
-	if slackErr != nil {
-		fmt.Printf("Warning: Error posting to #ask-cloud-platform %v\n", slackErr)
+	if err := slack.PostToAsk(prUrl, slackWebhookUrl); err != nil {
+		fmt.Printf("Warning: Error posting to #ask-cloud-platform: %v\n", err)
 	}
 }

--- a/pkg/environment/isRdsVersionMismatched.go
+++ b/pkg/environment/isRdsVersionMismatched.go
@@ -3,6 +3,7 @@ package environment
 import (
 	"errors"
 	"fmt"
+	"log"
 	"regexp"
 	"strconv"
 	"strings"
@@ -14,19 +15,17 @@ type RdsVersionResults struct {
 	TotalVersionMismatches int
 }
 
-func IsRdsVersionMismatched(outputTerraform string) (*RdsVersionResults, error) {
-	match, _ := regexp.MatchString("Error: updating RDS .* api error InvalidParameterCombination:.* from .* (?:to|with requested version) .*", outputTerraform)
-
+func IsRdsVersionMismatched(csvErr string) (*RdsVersionResults, error) {
+	match, _ := regexp.MatchString("Error: updating RDS .* api error InvalidParameterCombination:.* from .* (?:to|with requested version) .*", csvErr)
 	if !match {
 		return nil, errors.New("terraform is failing but it doesn't look like a rds version mismatch")
 	}
 
-	versionRe := regexp.MustCompile(`from (?P<actual_db_version>\d+\.\d+) (?:to|with requested version) (?P<terraform_db_version>\d+\.\d+)`)
+	versionRegex := regexp.MustCompile(`(?i)from ([^\s]+) (?:to|with requested version) ([^\s]+)`)
+	versionMatches := versionRegex.FindAllStringSubmatch(csvErr, -1)
 
-	moduleNameRe := regexp.MustCompile(`with module\.(.+)\.(?:aws_db_instance\.rds|aws_rds_cluster\.aurora),`)
-
-	moduleMatches := moduleNameRe.FindAllStringSubmatch(outputTerraform, -1)
-	versionMatches := versionRe.FindAllStringSubmatch(outputTerraform, -1)
+	moduleNameRe := regexp.MustCompile(`with module\.([^\s,]+?)\.aws_db_instance\.rds|aws_rds_cluster\.aurora,?`)
+	moduleMatches := moduleNameRe.FindAllStringSubmatch(csvErr, -1)
 
 	sanitisedVersions := removeInputStr(versionMatches)
 	sanitisedNames := removeInputStr(moduleMatches)
@@ -36,43 +35,44 @@ func IsRdsVersionMismatched(outputTerraform string) (*RdsVersionResults, error) 
 	}
 
 	if len(sanitisedVersions) != len(sanitisedNames) {
-		return nil, fmt.Errorf("error: there is an inconistent number of versions vs module names, there should be an even amount but we have %d sets of versions and %d module names", len(sanitisedVersions), len(sanitisedNames))
+		return nil, fmt.Errorf("error: there is an inconsistent number of versions vs module names, there should be an even amount but we have %d sets of versions and %d module names", len(sanitisedVersions), len(sanitisedNames))
 	}
 
 	return &RdsVersionResults{
-		sanitisedVersions,
-		sanitisedNames,
-		len(sanitisedVersions),
+		Versions:               sanitisedVersions,
+		ModuleNames:            sanitisedNames,
+		TotalVersionMismatches: len(sanitisedVersions),
 	}, nil
 }
 
 func checkVersionDowngrade(versions [][]string) bool {
-	isValid := true
-
-	for _, inner := range versions {
-		if len(inner) == 2 {
-			splitAcc := strings.Split(inner[0], ".")
-			splitTf := strings.Split(inner[1], ".")
-
-			adjustedAcc := strings.Join(splitAcc, "")
-			adjustedTf := strings.Join(splitTf, "")
-
-			acc, accErr := strconv.ParseInt(adjustedAcc, 0, 64)
-			tf, tfErr := strconv.ParseInt(adjustedTf, 0, 64)
-
-			isUpgrade := tf > acc
-
-			if accErr != nil || tfErr != nil || isUpgrade {
-				isValid = false
-				break
-			}
-		} else {
-			isValid = false
-			break
+	for _, pair := range versions {
+		if len(pair) != 2 {
+			log.Printf("Skipping invalid version pair: %v", pair)
+			return false
 		}
-	}
+		actual, desired := strings.Trim(pair[0], " ,."), strings.Trim(pair[1], " ,.")
 
-	return isValid
+		actInt, actErr := versionToInt(actual)
+		desInt, desErr := versionToInt(desired)
+
+		if actErr == nil && desErr == nil {
+			if desInt >= actInt {
+				return false
+			}
+			continue
+		}
+
+		return false
+	}
+	return true
+}
+
+func versionToInt(version string) (int64, error) {
+	parts := strings.FieldsFunc(version, func(r rune) bool {
+		return !(r >= '0' && r <= '9')
+	})
+	return strconv.ParseInt(strings.Join(parts, ""), 10, 64)
 }
 
 func removeInputStr(res [][]string) [][]string {

--- a/pkg/environment/isRdsVersionMismatched_test.go
+++ b/pkg/environment/isRdsVersionMismatched_test.go
@@ -1,132 +1,149 @@
 package environment_test
 
 import (
-	"errors"
-	"fmt"
-	"reflect"
+	"encoding/csv"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/ministryofjustice/cloud-platform-cli/pkg/environment"
 )
 
-var mismatchOutput = `2024/09/13 07:08:05 Running Terraform Apply for namespace: foobar
-
-FATA[2623] error running terraform on namespace foobar: unable to apply Terraform: exit status 1
-
-
-Error: updating RDS DB Instance (cloud-platform-123456789): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: xxxxxxxx-yyyyyy-zzzzzzzzz-, api error InvalidParameterCombination: Cannot upgrade postgres from 14.12 to 14.10
-
-
-  with module.rds_example_module_name.aws_db_instance.rds,
-
-  on .terraform/modules/foobar/main.tf line 166, in resource "aws_db_instance" "rds":
-
- 166: resource "aws_db_instance" "rds" {`
-
-var multipleMismatchOutput = `2024/09/13 07:08:05 Running Terraform Apply for namespace: foobar
-
-FATA[2623] error running terraform on namespace foobar: unable to apply Terraform: exit status 1
-
-
-Error: updating RDS DB Instance (cloud-platform-123456789): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: xxxxxxxx-yyyyyy-zzzzzzzzz-, api error InvalidParameterCombination: Cannot upgrade postgres from 14.12 to 14.10
-
-
-  with module.rds_example_module_name.aws_db_instance.rds,
-
-  on .terraform/modules/foobar/main.tf line 166, in resource "aws_db_instance" "rds":
-
- 166: resource "aws_db_instance" "rds" {
-
-
-Error: updating RDS DB Instance (cloud-platform-xxx): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: xxxxxxxx-yyyyyy-zzzzzzzzz-, api error InvalidParameterCombination: Cannot upgrade postgres from 16.18 to 16.16
-
-
-  with module.rds_example_module_name_2.aws_db_instance.rds,
-
-  on .terraform/modules/foobar/main.tf line 166, in resource "aws_db_instance" "rds":
-
- 166: resource "aws_db_instance" "rds" {`
-
-var nomatchOutput = "some random string not containing the right error"
-
-var isVersionUpgradeMismatch = `2024/09/13 07:08:05 Running Terraform Apply for namespace: foobar
-
-FATA[2623] error running terraform on namespace foobar: unable to apply Terraform: exit status 1
-
-
-Error: updating RDS DB Instance (cloud-platform-123456789): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: xxxxxxxx-yyyyyy-zzzzzzzzz-, api error InvalidParameterCombination: Cannot upgrade postgres from 14.12 to 14.19
-
-
-  with module.rds_example_module_name.aws_db_instance.rds,
-
-  on .terraform/modules/foobar/main.tf line 166, in resource "aws_db_instance" "rds":
-
- 166: resource "aws_db_instance" "rds" {`
-
-var inconsistentOutput = `2024/09/13 07:08:05 Running Terraform Apply for namespace: foobar
-
-FATA[2623] error running terraform on namespace foobar: unable to apply Terraform: exit status 1
-
-
-Error: updating RDS DB Instance (cloud-platform-123456789): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: xxxxxxxx-yyyyyy-zzzzzzzzz-, api error InvalidParameterCombination: Cannot upgrade postgres from 14.12 to 14.10
-
-
-  with module.rds_example_module_name.aws_db_instance.rds,
-  with module.rds_example_module_name_2.aws_db_instance.rds,
-  with module.rds_example_module_name_3.aws_db_instance.rds,
-
-  on .terraform/modules/foobar/main.tf line 166, in resource "aws_db_instance" "rds":
-
- 166: resource "aws_db_instance" "rds" {`
+func createTempCsv(t *testing.T, content string) string {
+	t.Helper()
+	tmpFile, err := os.CreateTemp("", "rds-drift-test-*.csv")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	if _, err := tmpFile.Write([]byte(content)); err != nil {
+		t.Fatalf("Failed to write to temp file: %v", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("Failed to close temp file: %v", err)
+	}
+	return tmpFile.Name()
+}
 
 func TestIsRdsVersionMismatched(t *testing.T) {
+	csvData := `foobar-ns-postgres-downgrade,Error: updating RDS DB Instance (cloud-platform-x): operation error RDS: ModifyDBInstance, api error InvalidParameterCombination: Cannot upgrade postgres from 14.13 to 14.7., with module.rds.aws_db_instance.rds,
+foobar-ns-rds-non-downgrade,Error: updating RDS DB Instance (cloud-platform-y): operation error RDS: ModifyDBInstance, api error InvalidParameterCombination: Max storage size must be greater than storage size, with module.rds.aws_db_instance.rds,
+foobar-ns-oracle-upgrade,Error: updating RDS DB Instance (cloud-platform-z): operation error RDS: ModifyDBInstance, api error InvalidParameterCombination: Cannot upgrade oracle-ee from 19.0.0.0.ru-2024-10.rur-2024-10.r1 to 19.0.0.0.ru-2025-01.rur-2025-01.r1, with module.oracle.aws_db_instance.rds,
+foobar-ns-oracle-downgrade,Error: updating RDS DB Instance (cloud-platform-a): operation error RDS: ModifyDBInstance, api error InvalidParameterCombination: Cannot upgrade oracle-ee from 19.0.0.0.ru-2025-10.rur-2025-10.r1 to 19.0.0.0.ru-2024-01.rur-2024-01.r1, with module.oracle.aws_db_instance.rds,
+foobar-ns-postgres-upgrade,Error: updating RDS DB Instance (cloud-platform-w): operation error RDS: ModifyDBInstance, api error InvalidParameterCombination: Cannot upgrade postgres from 14.7 to 14.13, with module.rds.aws_db_instance.rds,
+foobar-ns-mariadb-downgrade,Error: updating RDS DB Instance (cloud-platform-s): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: xxx, api error InvalidParameterCombination: Cannot upgrade mariadb from 10.11.8 to 10.11.6, with module.rds.aws_db_instance.rds,
+foobar-ns-mariadb-upgrade,Error: updating RDS DB Instance (cloud-platform-s): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: yyy, api error InvalidParameterCombination: Cannot upgrade mariadb from 10.11.8 to 10.11.9, with module.rds.aws_db_instance.rds,
+foobar-ns-postrgres-same-ns,Error: updating RDS DB Instance (cloud-platform-01152bdef9e4faaf): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: zzz, api error InvalidParameterCombination: Cannot upgrade postgres from 16.6 to 16.4, with module.rds_2.aws_db_instance.rds,
+foobar-ns-postrgres-same-ns,Error: updating RDS DB Instance (cloud-platform-35c7710fbe6aa229): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: aaa, api error InvalidParameterCombination: Cannot upgrade postgres from 16.6 to 16.4, with module.rds.aws_db_instance.rds,
+foobar-ns-invalid-version-format,Error: updating RDS DB Instance: api error InvalidParameterCombination: Cannot upgrade postgres from x.y to z.q, with module.rds.aws_db_instance.rds,
+foobar-ns-missing-module-name,Error: updating RDS DB Instance: api error InvalidParameterCombination: Cannot upgrade postgres from 13.6 to 12.4,
+foobar-ns-oracle-same-ru-upgrade,Error: updating RDS DB Instance (cloud-platform-test): operation error RDS: ModifyDBInstance, api error InvalidParameterCombination: Cannot upgrade oracle-ee from 19.0.0.0.ru-2025-01.rur-2025-01.r1 to 19.0.0.0.ru-2025-01.rur-2025-01.r2, with module.oracle.aws_db_instance.rds,
+`
+
+	tmpFile := createTempCsv(t, csvData)
+	defer os.Remove(tmpFile)
+
+	file, err := os.Open(tmpFile)
+	if err != nil {
+		t.Fatalf("Failed to open temp CSV: %v", err)
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	reader.TrimLeadingSpace = true
+	reader.FieldsPerRecord = -1
+
+	records, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("Failed to parse CSV: %v", err)
+	}
+
+	namespaceMap := make(map[string][]string)
+	for _, record := range records {
+		if len(record) < 2 {
+			t.Logf("Skipping incomplete record: %v", record)
+			continue
+		}
+		namespace := strings.TrimSpace(record[0])
+		errorMsg := strings.TrimSpace(strings.Join(record[1:], " "))
+		namespaceMap[namespace] = append(namespaceMap[namespace], errorMsg)
+	}
+
 	tests := []struct {
 		testDescription string
-		tfOutput        string
-		expectedRes     *environment.RdsVersionResults
-		wantErr         error
+		ns              string
+		wantErr         string
+		wantSuccess     bool
 	}{
 		{
-			"GIVEN an output WITH a version mismatch THEN return the correct strings", mismatchOutput, &environment.RdsVersionResults{
-				Versions:               [][]string{{"14.12", "14.10"}},
-				ModuleNames:            [][]string{{"rds_example_module_name"}},
-				TotalVersionMismatches: 1,
-			},
-			nil,
+			testDescription: "GIVEN a downgrade mismatch for postgres THEN expect a VALID RESULT",
+			ns:              "foobar-ns-postgres-downgrade",
+			wantSuccess:     true,
 		},
-		{"GIVEN an output WITHOUT a version mismatch THEN return nil", nomatchOutput, nil, errors.New("terraform is failing but it doesn't look like a rds version mismatch")},
-		{"GIVEN an output WITH a version mismatch BUT the mismatch would cause a db UPGRADE THEN return nil", isVersionUpgradeMismatch, nil, errors.New("terraform is failing, but it isn't trying to downgrade the RDS versions so it needs more investigation")},
 		{
-			"GIVEN an output WITH MULTIPLE version mismatches THEN return the correct string slices", multipleMismatchOutput, &environment.RdsVersionResults{
-				Versions:               [][]string{{"14.12", "14.10"}, {"16.18", "16.16"}},
-				ModuleNames:            [][]string{{"rds_example_module_name"}, {"rds_example_module_name_2"}},
-				TotalVersionMismatches: 2,
-			},
-			nil,
+			testDescription: "GIVEN a storage error THEN expect a INVALID RESULT due to non-mismatch RDS error",
+			ns:              "foobar-ns-rds-non-downgrade",
+			wantErr:         "terraform is failing but it doesn't look like a rds version mismatch",
 		},
-		{"GIVEN an output with an inconsistent number of versions and modules THEN return nil and an error", inconsistentOutput, nil, errors.New("error: there is an inconistent number of versions vs module names, there should be an even amount but we have 1 sets of versions and 3 module names")},
+		{
+			testDescription: "GIVEN an upgrade for oracle THEN expect a INVALID RESULT due to upgrade",
+			ns:              "foobar-ns-oracle-upgrade",
+			wantErr:         "terraform is failing, but it isn't trying to downgrade the RDS versions so it needs more investigation",
+		},
+		{
+			testDescription: "GIVEN a downgrade mismatch for oracle THEN expect a VALID RESULT",
+			ns:              "foobar-ns-oracle-downgrade",
+			wantSuccess:     true,
+		},
+		{
+			testDescription: "GIVEN an upgrade for postgres THEN expect a INVALID RESULT due to upgrade",
+			ns:              "foobar-ns-postgres-upgrade",
+			wantErr:         "terraform is failing, but it isn't trying to downgrade the RDS versions so it needs more investigation",
+		},
+		{
+			testDescription: "GIVEN a downgrade mismatch for mariadb THEN expect a VALID RESULT",
+			ns:              "foobar-ns-mariadb-downgrade",
+			wantSuccess:     true,
+		},
+		{
+			testDescription: "GIVEN an upgrade for mariadb THEN expect a INVALID RESULT due to upgrade",
+			ns:              "foobar-ns-mariadb-upgrade",
+			wantErr:         "terraform is failing, but it isn't trying to downgrade the RDS versions so it needs more investigation",
+		},
+		{
+			testDescription: "GIVEN multiple downgrade errors in the same namespace THEN expect a VALID RESULT",
+			ns:              "foobar-ns-postrgres-same-ns",
+			wantSuccess:     true,
+		},
+		{
+			testDescription: "GIVEN an invalid version format THEN expect a INVALID RESULT due to failed version parsing",
+			ns:              "foobar-ns-invalid-version-format",
+			wantErr:         "terraform is failing, but it isn't trying to downgrade the RDS versions so it needs more investigation",
+		},
+		{
+			testDescription: "GIVEN a missing module name THEN expect a INVALID RESULT due to missing module and inconsistent version and module count",
+			ns:              "foobar-ns-missing-module-name",
+			wantErr:         "error: there is an inconsistent number of versions vs module names, there should be an even amount but we have 1 sets of versions and 0 module names",
+		},
+		{
+			testDescription: "GIVEN an upgrade for oracle (same date but newer release version) THEN expect a INVALID RESULT due to upgrade",
+			ns:              "foobar-ns-oracle-same-ru-upgrade",
+			wantErr:         "terraform is failing, but it isn't trying to downgrade the RDS versions so it needs more investigation",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.testDescription, func(t *testing.T) {
-			fmt.Printf("Running test: %s\n", tt.testDescription)
+			msgs := strings.Join(namespaceMap[tt.ns], "\n")
+			_, err := environment.IsRdsVersionMismatched(msgs)
 
-			res, err := environment.IsRdsVersionMismatched(tt.tfOutput)
-			if tt.wantErr != nil {
-				if tt.wantErr.Error() != err.Error() {
-					t.Errorf("Expected an error = %v, but did not the receive expected error, actual error = %v", tt.wantErr.Error(), err.Error())
+			if tt.wantSuccess {
+				if err != nil {
+					t.Errorf("Expected no error, got %v", err)
 				}
-			}
-
-			if tt.expectedRes == nil {
-				if res != nil {
-					t.Errorf("Expected result to be nil but received %v", res)
+			} else {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Errorf("Expected error %q but got %v", tt.wantErr, err)
 				}
-				return
-			}
-
-			if !reflect.DeepEqual(*tt.expectedRes, *res) {
-				t.Errorf("IsRdsVersionMismatched() = %v, want %v", res, tt.expectedRes)
 			}
 		})
 	}

--- a/pkg/environment/namespace.go
+++ b/pkg/environment/namespace.go
@@ -122,7 +122,7 @@ func (a *Apply) nsCreateRawChangedFilesInPR(cluster string, prNumber int) ([]str
 			return nil, fmt.Errorf("failed to get raw contents: %s", err)
 		}
 		// Create List with changed files
-		if err := os.WriteFile(*file.Filename, data, 0644); err != nil {
+		if err := os.WriteFile(*file.Filename, data, 0o644); err != nil {
 			return nil, fmt.Errorf("failed to write file list: %s", err)
 		}
 	}
@@ -157,11 +157,11 @@ func canCreateNamespaces(namespaces []string, cluster string) (bool, error) {
 	for _, ns := range namespaces {
 		// make directory if it doesn't exist
 		if _, err := os.Stat(wd + "/namespaces/" + cluster + "/" + ns); err != nil {
-			err := os.Mkdir(wd+"/namespaces/"+cluster+"/"+ns, 0755)
+			err := os.Mkdir(wd+"/namespaces/"+cluster+"/"+ns, 0o755)
 			if err != nil {
 				return false, fmt.Errorf("error creating namespaces directory: %s", err)
 			}
-			err = os.Mkdir(wd+"/namespaces/"+cluster+"/"+ns+"/resources", 0755)
+			err = os.Mkdir(wd+"/namespaces/"+cluster+"/"+ns+"/resources", 0o755)
 			if err != nil {
 				return false, fmt.Errorf("error creating resources directory: %s", err)
 			}

--- a/pkg/environment/rdsDriftChecker.go
+++ b/pkg/environment/rdsDriftChecker.go
@@ -1,0 +1,176 @@
+package environment
+
+import (
+	"encoding/csv"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/ministryofjustice/cloud-platform-cli/pkg/github"
+	"github.com/spf13/cobra"
+)
+
+func RdsDriftChecker(cmd *cobra.Command, args []string) error {
+	sourceLocation := args[0]
+	localCSV := "merged-rds-errored-namespaces.csv"
+
+	if strings.HasPrefix(sourceLocation, "file://") {
+		localFilePath := strings.TrimPrefix(sourceLocation, "file://")
+		fmt.Printf("Using local CSV file: %s\n", localFilePath)
+
+		data, err := os.ReadFile(localFilePath)
+		if err != nil {
+			return fmt.Errorf("error reading local CSV: %v", err)
+		}
+		if err := os.WriteFile(localCSV, data, 0o644); err != nil {
+			return fmt.Errorf("error copying local CSV: %v", err)
+		}
+	} else {
+		fmt.Printf("Downloading CSV from S3: %s\n", sourceLocation)
+		if err := downloadFromS3(sourceLocation, localCSV); err != nil {
+			return fmt.Errorf("error downloading CSV: %v", err)
+		}
+	}
+
+	file, err := os.Open(localCSV)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	reader.TrimLeadingSpace = true
+
+	records, err := reader.ReadAll()
+	if err != nil {
+		return err
+	}
+
+	nsMap := make(map[string][]string)
+	for _, record := range records {
+		if len(record) < 2 {
+			log.Printf("Skipping incomplete record: %v\n", record)
+			continue
+		}
+		namespace := strings.TrimSpace(record[0])
+		errorMsg := strings.TrimSpace(strings.Join(record[1:], " "))
+		nsMap[namespace] = append(nsMap[namespace], errorMsg)
+	}
+
+	ghClient := github.NewGithubClient(&github.GithubClientConfig{
+		Repository: "cloud-platform-environments",
+		Owner:      "ministryofjustice",
+	}, os.Getenv("TF_VAR_github_token"))
+
+	successes := make(map[string]string)
+	failures := make(map[string]string)
+
+	for namespace, errorsList := range nsMap {
+		combinedErrorMsg := strings.Join(errorsList, "\n")
+		prURL, err := processRecord(namespace, combinedErrorMsg, ghClient)
+		if err != nil {
+			log.Printf("Failed to process namespace %s: %v\n\n", namespace, err)
+			failures[namespace] = err.Error()
+			continue
+		}
+		successes[namespace] = prURL
+	}
+
+	dupNsCount := 0
+	totalRdsDowngrade := 0
+	errInfo := []string{}
+	for ns, msgs := range nsMap {
+		if len(msgs) > 1 {
+			dupNsCount++
+			totalRdsDowngrade += len(msgs)
+			errInfo = append(errInfo, fmt.Sprintf("%s (%d downgrade)", ns, len(msgs)))
+		}
+	}
+
+	log.Println("\n\n==================== SUMMARY ====================")
+	fmt.Printf("Total CSV records: %d\n", len(records))
+	fmt.Printf("Unique namespaces processed: %d\n", len(nsMap))
+	if dupNsCount > 0 {
+		fmt.Printf("\nNamespaces with multiple RDS downgrade: %d (containing %d RDS downgrade records)\n", dupNsCount, totalRdsDowngrade)
+		for _, info := range errInfo {
+			fmt.Printf("  - %s\n", info)
+		}
+	}
+	if len(successes) > 0 {
+		fmt.Printf("\nSuccessfully created PRs (%d):\n", len(successes))
+		for ns, url := range successes {
+			fmt.Printf("  - %s: %s\n", ns, url)
+		}
+	}
+	if len(failures) > 0 {
+		fmt.Printf("\nFailed to process namespaces (%d):\n", len(failures))
+		for ns, reason := range failures {
+			fmt.Printf("  - %s: %s\n", ns, reason)
+		}
+	}
+
+	if len(failures) > 0 {
+		fmt.Printf("\n")
+		return fmt.Errorf("failed to process %d namespaces", len(failures))
+	}
+
+	return nil
+}
+
+func downloadFromS3(s3Location, localPath string) error {
+	cmd := exec.Command("aws", "s3", "cp", s3Location, localPath)
+	return cmd.Run()
+}
+
+func processRecord(namespace, csvErr string, ghClient github.GithubIface) (string, error) {
+	log.Printf("Processing namespace: %s", namespace)
+
+	results, err := IsRdsVersionMismatched(csvErr)
+	if err != nil {
+		return "", fmt.Errorf("parsing terraform error failed: %v", err)
+	}
+
+	tfDir := "namespaces/live.cloud-platform.service.justice.gov.uk/" + namespace + "/resources"
+
+	var filesChanged []string
+	versionDescription := fmt.Sprintf("- Fix Terraform RDS version drift for namespace: `%s`\n\n```", namespace)
+
+	for i, versions := range results.Versions {
+		moduleName := results.ModuleNames[i][0]
+		actualVersion := versions[0]
+		tfVersion := versions[1]
+
+		files, updateErr := updateVersion(moduleName, actualVersion, tfVersion, tfDir)
+		if updateErr != nil {
+			return "", fmt.Errorf("error updating Terraform: %v", updateErr)
+		}
+
+		for _, f := range files {
+			duplicate := false
+			for _, v := range filesChanged {
+				if f == v {
+					duplicate = true
+					break
+				}
+			}
+			if !duplicate {
+				filesChanged = append(filesChanged, f)
+			}
+		}
+		versionDescription += fmt.Sprintf("\nmodule.%s: downgrade from %s to %s", moduleName, actualVersion, tfVersion)
+	}
+
+	versionDescription += "\n```"
+	description := versionDescription
+	prCreator := createPR(description, namespace, os.Getenv("TF_VAR_github_token"), "cloud-platform-environments")
+	prUrl, err := prCreator(ghClient, filesChanged)
+	if err != nil {
+		return "", fmt.Errorf("PR creation failed: %v", err)
+	}
+
+	log.Printf("Successfully created PR: %s\n\n", prUrl)
+	postPR(prUrl, os.Getenv("SLACK_WEBHOOK_URL"))
+	return prUrl, nil
+}

--- a/pkg/environment/updateVersion.go
+++ b/pkg/environment/updateVersion.go
@@ -7,78 +7,85 @@ import (
 	"strings"
 )
 
-func updateVersion(moduleName, actualDbVersion, terraformDbVersion, tfDir string) (string, error) {
-	grepCmd := exec.Command("/bin/sh", "-c", "grep -l 'module \""+moduleName+"\"' *")
+func updateVersion(moduleName, actualDbVersion, terraformDbVersion, tfDir string) ([]string, error) {
+	grepCmd := fmt.Sprintf("grep -l 'module \"%s\"' *.tf", moduleName)
+	cmd := exec.Command("/bin/sh", "-c", grepCmd)
+	cmd.Dir = tfDir
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to find module file: %w", err)
+	}
+	fileName := strings.TrimSpace(string(output))
 
-	grepCmd.Dir = tfDir
+	scanCmd := fmt.Sprintf("grep -A 40 'module \"%s\"' %s", moduleName, fileName)
+	cmd = exec.Command("/bin/sh", "-c", scanCmd)
+	cmd.Dir = tfDir
+	blockBytes, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	moduleBlock := string(blockBytes)
 
-	fileName, grepErr := grepCmd.Output()
+	lineRegex := regexp.MustCompile(`(?i)db_engine_version\s*=\s*(.+)`)
+	lineMatches := lineRegex.FindStringSubmatch(moduleBlock)
 
-	if grepErr != nil {
-		return "", grepErr
+	dbValue := strings.TrimSpace(lineMatches[1])
+
+	var changedFiles []string
+
+	if strings.Contains(dbValue, "var.") {
+		varName := strings.TrimSpace(strings.TrimPrefix(dbValue, "var."))
+		updated, varFile, err := updateVersionVariable(actualDbVersion, terraformDbVersion, tfDir, varName)
+		if err != nil {
+			return nil, err
+		}
+		if updated && varFile != "" {
+			changedFiles = append(changedFiles, varFile)
+		}
+	} else {
+		updated, err := updateVersionHardcode(moduleName, fileName, actualDbVersion, terraformDbVersion, tfDir)
+		if err != nil {
+			return nil, err
+		}
+		if updated {
+			changedFiles = append(changedFiles, fileName)
+		}
 	}
 
-	execLine := "grep -A 40 -n 'module \"" + moduleName + "\"' " + string(fileName)
-	lineCmd := exec.Command("/bin/sh", "-c", execLine)
-
-	lineCmd.Dir = tfDir
-
-	lineNum, lineErr := lineCmd.Output()
-
-	dbEngine := regexp.MustCompile(`(\d+).*engine_version`)
-	dbMatch := dbEngine.FindStringSubmatch(string(lineNum))
-
-	if dbMatch == nil {
-		return "", fmt.Errorf("no line match")
-	}
-
-	if lineErr != nil {
-		return "", lineErr
-	}
-
-	splitTfDbVersion := strings.Split(terraformDbVersion, ".")
-
-	escapedTfDbVersion := "\"" + splitTfDbVersion[0] + "\\." + splitTfDbVersion[1] + "\""
-
-	sedCmd := exec.Command("/bin/sh", "-c", "sed -i'' -e '"+dbMatch[1]+"s/"+escapedTfDbVersion+"/\""+actualDbVersion+"\"/g' "+string(fileName))
-
-	sedCmd.Dir = tfDir
-
-	sedErr := sedCmd.Run()
-
-	if sedErr != nil {
-		return "", sedErr
-	}
-
-	return string(fileName), nil
+	return changedFiles, nil
 }
 
-func checkRdsAndUpdate(tfErr, tfDir string) (string, []string, error) {
-	var filenames []string
+func updateVersionHardcode(moduleName, fileName, actualDbVersion, terraformDbVersion, tfDir string) (bool, error) {
+	sedCmd := fmt.Sprintf(
+		`sed -i -E '/module "%s"/,/^}/ s/"%s"/"%s"/g' %s`,
+		moduleName, terraformDbVersion, actualDbVersion, fileName,
+	)
+	execCmd := exec.Command("/bin/sh", "-c", sedCmd)
+	execCmd.Dir = tfDir
+	if err := execCmd.Run(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
 
-	matches, rdsErr := IsRdsVersionMismatched(tfErr)
-	versionDescription := "Fix Terraform RDS version drift. Here are the RDS version mismatches: \n\n"
+func updateVersionVariable(actualDbVersion, terraformDbVersion, tfDir, varName string) (bool, string, error) {
+	grepVarCmd := fmt.Sprintf("grep -l 'variable \"%s\"' *.tf", varName)
+	cmd := exec.Command("/bin/sh", "-c", grepVarCmd)
+	cmd.Dir = tfDir
+	varOutput, err := cmd.Output()
+	if err != nil {
+		return false, "", fmt.Errorf("failed to find variable definition for %s: %w", varName, err)
+	}
+	varFile := strings.TrimSpace(string(varOutput))
 
-	if rdsErr != nil {
-		return "", nil, rdsErr
+	varSedCmd := fmt.Sprintf(
+		"sed -i -E 's/default[[:space:]]*=[[:space:]]*\"%s\"/default = \"%s\"/' %s",
+		terraformDbVersion, actualDbVersion, varFile)
+	cmd = exec.Command("/bin/sh", "-c", varSedCmd)
+	cmd.Dir = tfDir
+	if err := cmd.Run(); err != nil {
+		return false, "", fmt.Errorf("failed to update variable default: %w", err)
 	}
 
-	for i := 0; i < matches.TotalVersionMismatches; i++ {
-		moduleName := matches.ModuleNames[i][0]
-		actualDbVersion := matches.Versions[i][0]
-		terraformDbVersion := matches.Versions[i][1]
-
-		versionDescription += versionDescription + "downgrade from " + actualDbVersion + " to " + terraformDbVersion + "\n"
-
-		file, updateErr := updateVersion(moduleName, actualDbVersion, terraformDbVersion, tfDir)
-
-		filenames = append(filenames, file)
-
-		if updateErr != nil {
-			return "", nil, updateErr
-		}
-
-	}
-
-	return versionDescription, filenames, nil
+	return true, varFile, nil
 }

--- a/pkg/terraform/utils_test.go
+++ b/pkg/terraform/utils_test.go
@@ -11,7 +11,7 @@ func Test_DeleteLocalState(t *testing.T) {
 	siblingDir := "testDir"
 
 	os.RemoveAll(parentDir)
-	err := os.Mkdir(parentDir, 0755)
+	err := os.Mkdir(parentDir, 0o755)
 	if err != nil {
 		t.Errorf("DeleteLocalState() error = %v", err)
 	}

--- a/pkg/util/filesystem.go
+++ b/pkg/util/filesystem.go
@@ -78,10 +78,8 @@ func ListFiles(path string) ([]string, error) {
 func IsFilePathExists(filePath string) (bool, error) {
 	if _, err := os.Stat(filePath); err == nil {
 		return true, nil
-
 	} else if errors.Is(err, os.ErrNotExist) {
 		return false, nil
-
 	} else {
 		return false, err
 	}

--- a/pkg/util/filesystem_test.go
+++ b/pkg/util/filesystem_test.go
@@ -99,7 +99,6 @@ func createTestFolderStructure(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-
 }
 
 func TestGetFolderChunks(t *testing.T) {


### PR DESCRIPTION
- This PR introduces functionality to automatically detect and fix Terraform RDS engine version drift across cloud-platform-environments repo, using CSV input from either S3 or a local file.

  - New CLI command: 
```
cloud-platform environment rds-drift-checker <file-location>

Supported formats:
    - s3://bucket/path/to/file.csv
    - file://local/path/to/file.csv (for testing/debugging)
```

- `RdsDriftChecker`:
    - Parses CSVs with namespace + error messages
    - Groups errors per namespace
    - Detects RDS version downgrade mismatches using `IsRdsVersionMismatched()`
    - Applies fixes by updating Terraform files
    - Opens a PR for each namespace
    - Handles both hardcoded and variable-based db_engine_version definitions
    - Ensures changes are scoped to the namespace only
    - Skips if an open PR already exists for the namespace
    - Auto-generates a branch name with a short UID
    - Commits and pushes version fix
    - Posts PR to Slack via webhook

- `IsRdsVersionMismatched`:
  - support postrgres (pattern with `14.14`)
  - support mariadb (pattern with `10.11.9`)
  - support oracle (pattern with `19.0.0.0.ru-2024-10.rur-2024-10.r1`)

- `TestIsRdsVersionMismatched`:
    - updated test with mock CSV test cases
    - Covers:
        - Downgrades
        - Upgrades
        - Non-version errors
        - Multiple errors per namespace
        - Incomplete rows

- Relates to https://github.com/ministryofjustice/cloud-platform/issues/6956