### PR TITLE
:robot_face: Fix:: add github origin in createPR

### DIFF
--- a/pkg/environment/createPR.go
+++ b/pkg/environment/createPR.go
@@ -26,6 +26,16 @@ func createPR(description, namespace, ghToken, repo string) func(github.GithubIf
 	return func(gh github.GithubIface, filenames []string) (string, error) {
 		repoPath := "namespaces/live.cloud-platform.service.justice.gov.uk/" + namespace + "/resources"
 
+		removeRemoteCmd := exec.Command("/bin/sh", "-c", "git remote remove origin")
+		if err := removeRemoteCmd.Run(); err != nil {
+			return "", fmt.Errorf("failed to remove remote origin: %w", err)
+		}
+
+		useGhTokenCmd := exec.Command("/bin/sh", "-c", "git remote add origin https://"+ghToken+"@github.com/ministryofjustice/"+repo)
+		if err := useGhTokenCmd.Run(); err != nil {
+			return "", fmt.Errorf("failed to remote add origin: %w", err)
+		}
+
 		pulls, err := gh.ListOpenPRs(namespace)
 		if err != nil {
 			log.Printf("Warning: error listing open PRs: %v", err)

--- a/pkg/environment/rdsDriftChecker.go
+++ b/pkg/environment/rdsDriftChecker.go
@@ -111,9 +111,15 @@ func RdsDriftChecker(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if len(failures) > 0 {
-		fmt.Printf("\n")
-		return fmt.Errorf("failed to process %d namespaces", len(failures))
+	criticalFailureCount := 0
+	for _, reason := range failures {
+		if strings.Contains(reason, "PR creation failed") {
+			criticalFailureCount++
+		}
+	}
+
+	if criticalFailureCount > 0 {
+		return fmt.Errorf("failed to create PR for %d namespaces", criticalFailureCount)
 	}
 
 	return nil


### PR DESCRIPTION
- add github origin in createPR

- update `RdsDriftChecker` to prevent noisy alarm with the namespace with non-downgrade rds error: 
  - return error if the fail is due to "PR creation failed" 
  - it can skip `parsing terraform error failed: terraform is failing but it doesn't look like a rds version mismatch` to return pipeline error. (for example rds with `Max storage size must be greater than storage size` error)