### PR TITLE
Removing obsolete variable that breaks pipeline

### DIFF
--- a/pkg/cluster/create.go
+++ b/pkg/cluster/create.go
@@ -108,14 +108,6 @@ func (c *Cluster) ApplyComponents(tf *terraform.TerraformCLIConfig, awsCreds *cl
 	// Reset any previous variables that might've been set.
 	tf.ApplyVars = nil
 
-	// Turn the monitoring options off.
-	vars := []string{
-		fmt.Sprintf("%s=%s", "pagerduty_config", "dummydummy"),
-	}
-	for _, v := range vars {
-		tf.ApplyVars = append(tf.ApplyVars, tfexec.Var(v))
-	}
-
 	// Auth to the cluster and write the kubeconfig to disk.
 	_, err := AuthToCluster(tf.Workspace, awsCreds.Eks, kubeconf, awsCreds.Profile)
 	if err != nil {

--- a/pkg/cluster/create.go
+++ b/pkg/cluster/create.go
@@ -111,7 +111,6 @@ func (c *Cluster) ApplyComponents(tf *terraform.TerraformCLIConfig, awsCreds *cl
 	// Turn the monitoring options off.
 	vars := []string{
 		fmt.Sprintf("%s=%s", "pagerduty_config", "dummydummy"),
-		fmt.Sprintf("%s=%s", "slack_hook_id", "dummydummy"),
 	}
 	for _, v := range vars {
 		tf.ApplyVars = append(tf.ApplyVars, tfexec.Var(v))


### PR DESCRIPTION
Fix for [failing pipeline create cluster](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/create-cluster/jobs/create/builds/496#L67dae7bd:98311:98316).
