### PR TITLE
fix: Update RDS drift checker

### DIFF
--- a/pkg/environment/createPR.go
+++ b/pkg/environment/createPR.go
@@ -57,6 +57,7 @@ func createPR(description, namespace, ghToken, repo string) func(github.GithubIf
 		addCmd := exec.Command("/bin/sh", "-c", "git add "+strings.Join(filenames, " "))
 		addCmd.Dir = repoPath
 		if err := addCmd.Run(); err != nil {
+			log.Printf("[ERROR] Failed to git add: %v", err)
 			return "", fmt.Errorf("failed to git add: %w", err)
 		}
 
@@ -65,17 +66,20 @@ func createPR(description, namespace, ghToken, repo string) func(github.GithubIf
 		)
 		commitCmd.Dir = repoPath
 		if err := commitCmd.Run(); err != nil {
+			log.Printf("[ERROR] Failed to git commit: %v", err)
 			return "", fmt.Errorf("failed to git commit: %w", err)
 		}
 
 		pushCmd := exec.Command("/bin/sh", "-c", "git push --set-upstream origin "+branchName)
 		pushCmd.Dir = repoPath
 		if err := pushCmd.Run(); err != nil {
+			log.Printf("[ERROR] Failed to push branch: %v", err)
 			return "", fmt.Errorf("failed to push branch: %w", err)
 		}
 
 		prUrl, err := gh.CreatePR(branchName, namespace, description)
 		if err != nil {
+			log.Printf("[ERROR] Failed to create GitHub PR: %v", err)
 			return "", fmt.Errorf("failed to create PR: %w", err)
 		}
 

--- a/pkg/environment/rdsDriftChecker.go
+++ b/pkg/environment/rdsDriftChecker.go
@@ -113,7 +113,8 @@ func RdsDriftChecker(cmd *cobra.Command, args []string) error {
 
 	criticalFailureCount := 0
 	for _, reason := range failures {
-		if strings.Contains(reason, "PR creation failed") {
+		if !strings.Contains(reason, "terraform is failing but it doesn't look like a rds version mismatch") &&
+			!strings.Contains(reason, "a PR is already open for this namespace") {
 			criticalFailureCount++
 		}
 	}

--- a/pkg/environment/updateVersion.go
+++ b/pkg/environment/updateVersion.go
@@ -2,12 +2,15 @@ package environment
 
 import (
 	"fmt"
+	"log"
 	"os/exec"
 	"regexp"
 	"strings"
 )
 
 func updateVersion(moduleName, actualDbVersion, terraformDbVersion, tfDir string) ([]string, error) {
+	log.Printf("Inputs - moduleName: %s, actualDbVersion: '%s', terraformDbVersion: '%s', tfDir: %s", moduleName, actualDbVersion, terraformDbVersion, tfDir)
+
 	grepCmd := fmt.Sprintf("grep -l 'module \"%s\"' *.tf", moduleName)
 	cmd := exec.Command("/bin/sh", "-c", grepCmd)
 	cmd.Dir = tfDir
@@ -16,8 +19,10 @@ func updateVersion(moduleName, actualDbVersion, terraformDbVersion, tfDir string
 		return nil, fmt.Errorf("failed to find module file: %w", err)
 	}
 	fileName := strings.TrimSpace(string(output))
+	log.Printf("Found module file: %s", fileName)
 
 	scanCmd := fmt.Sprintf("grep -A 40 'module \"%s\"' %s", moduleName, fileName)
+	log.Printf("Scanning module block: %s", scanCmd)
 	cmd = exec.Command("/bin/sh", "-c", scanCmd)
 	cmd.Dir = tfDir
 	blockBytes, err := cmd.Output()
@@ -30,6 +35,7 @@ func updateVersion(moduleName, actualDbVersion, terraformDbVersion, tfDir string
 	lineMatches := lineRegex.FindStringSubmatch(moduleBlock)
 
 	dbValue := strings.TrimSpace(lineMatches[1])
+	log.Printf("Found db_engine_version value: %s", dbValue)
 
 	var changedFiles []string
 
@@ -37,17 +43,21 @@ func updateVersion(moduleName, actualDbVersion, terraformDbVersion, tfDir string
 		varName := strings.TrimSpace(strings.TrimPrefix(dbValue, "var."))
 		updated, varFile, err := updateVersionVariable(actualDbVersion, terraformDbVersion, tfDir, varName)
 		if err != nil {
+			log.Printf("[ERROR] Failed to update variable version: %v", err)
 			return nil, err
 		}
 		if updated && varFile != "" {
+			log.Printf("Updated variable in file: %s", varFile)
 			changedFiles = append(changedFiles, varFile)
 		}
 	} else {
 		updated, err := updateVersionHardcode(moduleName, fileName, actualDbVersion, terraformDbVersion, tfDir)
 		if err != nil {
+			log.Printf("[ERROR] Failed to update hardcoded version: %v", err)
 			return nil, err
 		}
 		if updated {
+			log.Printf("Updated hardcoded version in file: %s", fileName)
 			changedFiles = append(changedFiles, fileName)
 		}
 	}
@@ -60,9 +70,12 @@ func updateVersionHardcode(moduleName, fileName, actualDbVersion, terraformDbVer
 		`sed -i -E '/module "%s"/,/^}/ s/"%s"/"%s"/g' %s`,
 		moduleName, terraformDbVersion, actualDbVersion, fileName,
 	)
+	log.Printf("Sed command: %s", sedCmd)
+
 	execCmd := exec.Command("/bin/sh", "-c", sedCmd)
 	execCmd.Dir = tfDir
 	if err := execCmd.Run(); err != nil {
+		log.Printf("[ERROR] Failed to update hardcoded version with sed: %v", err)
 		return false, err
 	}
 	return true, nil
@@ -81,9 +94,12 @@ func updateVersionVariable(actualDbVersion, terraformDbVersion, tfDir, varName s
 	varSedCmd := fmt.Sprintf(
 		"sed -i -E 's/default[[:space:]]*=[[:space:]]*\"%s\"/default = \"%s\"/' %s",
 		terraformDbVersion, actualDbVersion, varFile)
+	log.Printf("Sed command for variable update: %s", varSedCmd)
+
 	cmd = exec.Command("/bin/sh", "-c", varSedCmd)
 	cmd.Dir = tfDir
 	if err := cmd.Run(); err != nil {
+		log.Printf("[ERROR] Failed to update default value in variable file: %v", err)
 		return false, "", fmt.Errorf("failed to update variable default: %w", err)
 	}
 


### PR DESCRIPTION
- Some RDS downgrade error comes as below
```
Cannot find upgrade path from 14.19 to 14.17.,   with module.rds-instance.aws_db_instance.rds,
```
- for the extra dot in `14.17.`, current code cannot trim it and hence it cannot match the version in the environment repo tf code
 
- Update `removeInputStr` function to trim the version
-----
- Add and keep the debug log for future troubleshooting
----
- Skip counting below error as critical failures to reduce alert noise in lower priority channel.
```
- terraform is failing but it doesn't look like a rds version mismatch

- a PR is already open for this namespace
```
----
- Relates to https://github.com/ministryofjustice/cloud-platform/issues/7160