### PR TITLE
fix: re-encode escaped characters in secrets

### DIFF
--- a/pkg/decodeSecret/decodeSecret.go
+++ b/pkg/decodeSecret/decodeSecret.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"strconv"
+	"strings"
 )
 
 type secretDecoder struct {
@@ -81,6 +83,8 @@ func (sd *secretDecoder) processJson(jsn string, rawPrint bool) (string, error) 
 		return "", errors.New("unable to decode secret, does it have a data key?")
 	}
 
+	fmt.Println(data)
+
 	err = decodeKeys(data)
 	if err != nil {
 		return "", err
@@ -141,8 +145,18 @@ func base64decode(i interface{}) string {
 	return string(str)
 }
 
+func _UnescapeUnicodeCharactersInJSON(_jsonRaw json.RawMessage) (json.RawMessage, error) {
+	str, err := strconv.Unquote(strings.Replace(strconv.Quote(string(_jsonRaw)), `\\u`, `\u`, -1))
+	if err != nil {
+		return nil, err
+	}
+	return []byte(str), nil
+}
+
 func formatJson(result map[string]interface{}) (string, error) {
 	str, err := json.MarshalIndent(result, "", "    ")
+
+	str, _ = _UnescapeUnicodeCharactersInJSON(str)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/decodeSecret/decodeSecret.go
+++ b/pkg/decodeSecret/decodeSecret.go
@@ -143,7 +143,7 @@ func base64decode(i interface{}) string {
 	return string(str)
 }
 
-func _UnescapeUnicodeCharactersInJSON(_jsonRaw json.RawMessage) (json.RawMessage, error) {
+func unescapeUnicodeCharactersInJSON(_jsonRaw json.RawMessage) (json.RawMessage, error) {
 	str, err := strconv.Unquote(strings.Replace(strconv.Quote(string(_jsonRaw)), `\\u`, `\u`, -1))
 	if err != nil {
 		return nil, err
@@ -154,7 +154,7 @@ func _UnescapeUnicodeCharactersInJSON(_jsonRaw json.RawMessage) (json.RawMessage
 func formatJson(result map[string]interface{}) (string, error) {
 	str, err := json.MarshalIndent(result, "", "    ")
 
-	str, _ = _UnescapeUnicodeCharactersInJSON(str)
+	str, _ = unescapeUnicodeCharactersInJSON(str)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/decodeSecret/decodeSecret.go
+++ b/pkg/decodeSecret/decodeSecret.go
@@ -83,8 +83,6 @@ func (sd *secretDecoder) processJson(jsn string, rawPrint bool) (string, error) 
 		return "", errors.New("unable to decode secret, does it have a data key?")
 	}
 
-	fmt.Println(data)
-
 	err = decodeKeys(data)
 	if err != nil {
 		return "", err

--- a/pkg/decodeSecret/decodeSecret_test.go
+++ b/pkg/decodeSecret/decodeSecret_test.go
@@ -24,6 +24,17 @@ func TestDecodeSecret(t *testing.T) {
 	}
 }
 
+func TestUnescapeUnicodeCharactersInJSON(t *testing.T) {
+	escaped := []byte(`{"data": "\u003cbadger\u003c\u003e"}`)
+
+	expected := []byte(`{"data": "<badger<>"}`)
+
+	actual, err := unescapeUnicodeCharactersInJSON(escaped)
+	if err != nil || string(actual) != string(expected) {
+		t.Errorf("Expected:\n%s\nGot:\n%s\n", expected, actual)
+	}
+}
+
 func TestBadBase64(t *testing.T) {
 	jsn := `{ "data": { "key1": "1", "key2": "2" } }`
 


### PR DESCRIPTION
## 👀 Purpose

- Fixes string encoding in secrets

To test:

1. Checkout this branch
2. Run `make build`
3. Run `./cloud-platform-1.45.0-dirty decode-secret -n mikebell-test -s test-secret --skip-version-check`
4. You should see the secret `<badger<>`