### PR TITLE
Add dependency to skip Docker build if GoReleaser build fails

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -39,8 +39,7 @@ jobs:
   docker:
     name: Build container and push to DockerHub
     runs-on: ubuntu-latest
-    needs: build  
-    if: success()
+    needs: build
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 ##v4.2.2

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -39,6 +39,8 @@ jobs:
   docker:
     name: Build container and push to DockerHub
     runs-on: ubuntu-latest
+    needs: build  
+    if: success()
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 ##v4.2.2


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to ensure that the Docker build and push job only runs if the GoReleaser build completes successfully.

### Changes
- Added `needs: build` to the `docker` job.
- Ensures the “Build container and push to DockerHub” job is skipped automatically if the GoReleaser build fails.
- Prevents publishing partial or broken releases.

Previously, the Docker build would run even if the GoReleaser step failed, potentially leading to inconsistent or incomplete release artifacts. This change ensures dependent builds are only triggered after a successful GoReleaser release.
