### PR TITLE
fix: 🐛 pin opa version to 1.8 to ensure compat with os glibc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sLo ./kubectl https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/
 # Install terraform
 RUN curl -sLo terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && unzip terraform.zip
 
-RUN curl -sLo opa "https://openpolicyagent.org/downloads/latest/opa_linux_amd64"
+RUN curl -sLo opa "https://openpolicyagent.org/downloads/v1.8.0/opa_linux_amd64"
 
 RUN chmod +x kubectl terraform opa
 


### PR DESCRIPTION
fixes failing opa checks in concourse pipelines